### PR TITLE
Updated README to use module that contains cmake/3.20.0 and use public test-case repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ SCOREC Rhel7 environment
 ```
 module unuse /opt/scorec/spack/lmod/linux-rhel7-x86_64/Core
 module use /opt/scorec/spack/v0154_2/lmod/linux-rhel7-x86_64/Core
+module use /opt/scorec/modules
 module load \
 gcc/10.1.0 \
 mpich \
@@ -30,7 +31,7 @@ gdb
 Build, install, and test
 
 ```
-git clone git@github.com:SCOREC/wdmapp_testcases.git #test data
+git clone https://github.com/jacobmerson/pcms_testcases #test data
 git clone git@github.com:SCOREC/wdmapp_coupling.git
 
 cmake -S wdmapp_coupling -B buildWdmCpl \


### PR DESCRIPTION
Edited README.md to use the module directory: `/opt/scorec/modules`. It has several essential build tools, most importantly *cmake/3.20.0*.
Also changed the private `SCOREC/wdmapp_testcasestest` repo to a public repo: [https://github.com/jacobmerson/pcms_testcases](https://github.com/jacobmerson/pcms_testcases)