### PR TITLE
Find nearest element on 2D point search miss

### DIFF
--- a/src/pcms/omega_h_field.h
+++ b/src/pcms/omega_h_field.h
@@ -357,7 +357,7 @@ auto evaluate(
 
   Kokkos::parallel_for(
     results.size(), KOKKOS_LAMBDA(LO i) {
-      auto [elem_idx, coord] = results(i);
+      auto [dim, elem_idx, coord] = results(i);
       // TODO deal with case for elem_idx < 0 (point outside of mesh)
       KOKKOS_ASSERT(elem_idx >= 0);
       const auto elem_tri2verts =
@@ -397,7 +397,7 @@ auto evaluate(
 
   Kokkos::parallel_for(
     results.size(), KOKKOS_LAMBDA(LO i) {
-      auto [elem_idx, coord] = results(i);
+      auto [dim, elem_idx, coord] = results(i);
       // TODO deal with case for elem_idx < 0 (point outside of mesh)
       KOKKOS_ASSERT(elem_idx >= 0);
       const auto elem_tri2verts =

--- a/src/pcms/omega_h_field.h
+++ b/src/pcms/omega_h_field.h
@@ -453,15 +453,31 @@ public:
     PCMS_FUNCTION_TIMER;
     Omega_h::Write<Omega_h::I8> owned_mask(mesh.nents(0));
     auto owned = mesh.owned(0);
-    Omega_h::parallel_for(
-      owned_mask.size(), OMEGA_H_LAMBDA(LO i) { 
-      if(mask.exists()) {
-        owned_mask[i] = mask[i] && owned[i];
-        }
-      else {
+    struct OwnedMaskFunctor
+    {
+      Omega_h::Read<Omega_h::I8> mask;
+      Omega_h::Read<Omega_h::I8> owned;
+      Omega_h::Write<Omega_h::I8> owned_mask;
+
+      OwnedMaskFunctor(Omega_h::Read<Omega_h::I8> mask_,
+                       Omega_h::Read<Omega_h::I8> owned_,
+                       Omega_h::Write<Omega_h::I8> owned_mask_)
+        : mask(mask_), owned(owned_), owned_mask(owned_mask_)
+      {
+      }
+
+      OMEGA_H_DEVICE void operator()(LO i) const
+      {
+        if (mask.exists()) {
+          owned_mask[i] = mask[i] && owned[i];
+        } else {
           owned_mask[i] = owned[i];
         }
-      });
+      }
+    };
+
+    Omega_h::parallel_for(owned_mask.size(),
+                          OwnedMaskFunctor(mask, owned, owned_mask));
     field_ = OmegaHField<T, CoordinateElementType>(name,           mesh,      Omega_h::Read<Omega_h::I8>(owned_mask),
              global_id_name);
   }

--- a/src/pcms/point_search.cpp
+++ b/src/pcms/point_search.cpp
@@ -277,10 +277,6 @@ Kokkos::View<GridPointSearch::Result*> GridPointSearch::operator()(Kokkos::View<
     auto dimensionality = GridPointSearch::Result::Dimensionality::EDGE;
     Omega_h::Real distance_to_nearest { INFINITY };
     Omega_h::Vector<3> parametric_coords_to_nearest;
-
-    // auto trisToEdges = mesh_.ask_down(Omega_h::FACE, OMEGA_H_EDGE);
-    // auto trisToVerts = mesh_.ask_down(Omega_h::FACE, OMEGA_H_VERT);
-
     // create array that's size of number of candidates x num coords to store
     // parametric inversion
     for (auto i = candidates_begin; i < candidates_end; ++i) {
@@ -290,7 +286,6 @@ Kokkos::View<GridPointSearch::Result*> GridPointSearch::operator()(Kokkos::View<
       // 2d mesh with 2d coords, but 3 triangles
      auto vertex_coords = Omega_h::gather_vectors<3, 2>(coords, elem_tri2verts);
      auto parametric_coords = barycentric_from_global(point, vertex_coords);
-     const auto centroid = Omega_h::average(vertex_coords);
 
      auto vertex_a = vertex_coords[0];
      auto vertex_b = vertex_coords[1];
@@ -311,11 +306,8 @@ Kokkos::View<GridPointSearch::Result*> GridPointSearch::operator()(Kokkos::View<
        const auto xp = point[0];
        const auto yp = point[1];
 
-        const auto distance_to_ab = distance_from_line(xp, yp, xa, ya, xb, yb);
-        const auto distance_to_bc = distance_from_line(xp, yp, xb, yb, xc, yc);
-        const auto distance_to_ac = distance_from_line(xp, yp, xc, yc, xa, ya);
-
         if (within_ab) {
+          const auto distance_to_ab = distance_from_line(xp, yp, xa, ya, xb, yb);
           if (distance_to_ab < distance_to_nearest) {
             dimensionality = GridPointSearch::Result::Dimensionality::EDGE;
             nearest_triangle = i;
@@ -323,6 +315,7 @@ Kokkos::View<GridPointSearch::Result*> GridPointSearch::operator()(Kokkos::View<
             parametric_coords_to_nearest = parametric_coords;
           }
         } else if (within_bc) {
+          const auto distance_to_bc = distance_from_line(xp, yp, xb, yb, xc, yc);
           if (distance_to_bc < distance_to_nearest) {
             dimensionality = GridPointSearch::Result::Dimensionality::EDGE;
             nearest_triangle = i;
@@ -331,6 +324,7 @@ Kokkos::View<GridPointSearch::Result*> GridPointSearch::operator()(Kokkos::View<
           }
         }
 
+        const auto distance_to_ac = distance_from_line(xp, yp, xc, yc, xa, ya);
         if (distance_to_ac < distance_to_nearest) {
           dimensionality = GridPointSearch::Result::Dimensionality::EDGE;
           nearest_triangle = i;

--- a/src/pcms/point_search.cpp
+++ b/src/pcms/point_search.cpp
@@ -326,7 +326,7 @@ Kokkos::View<GridPointSearch::Result*> GridPointSearch::operator()(Kokkos::View<
       // Every triangle (face) is connected to 3 vertices
       for (int j = 0; j < 3; ++j) {
         // Get the vertex ID from the connectivity array
-        const int vertexID = tris2verts_adj_.ab2b[triangleID * 3 + j];
+        const int vertexID = tris2verts_adj.ab2b[triangleID * 3 + j];
         // Get the vertex coordinates from the mesh using vertexID
         const Omega_h::Few<double, 2> vertex =
           Omega_h::get_vector<2>(coords, vertexID);

--- a/src/pcms/point_search.cpp
+++ b/src/pcms/point_search.cpp
@@ -3,6 +3,7 @@
 #include <bitset>
 
 // From https://en.wikipedia.org/wiki/Distance_from_a_point_to_a_line#Line_defined_by_two_points
+KOKKOS_INLINE_FUNCTION
 double distance_from_line(const double x0, const double y0, const double x1, const double y1, const double x2, const double y2)
 {
   const Omega_h::Vector<2> p1 = { x1, y1 };
@@ -13,11 +14,13 @@ double distance_from_line(const double x0, const double y0, const double x1, con
 }
 
 // Law of Cosines, where a, b, c and gamma are defined here: https://en.wikipedia.org/wiki/Law_of_cosines#Use_in_solving_triangles
+KOKKOS_INLINE_FUNCTION
 double angle_from_side_lengths(const double a, const double b, const double c)
 {
   return std::acos((a*a + b*b - c*c) / 2*a*b);
 }
 
+KOKKOS_INLINE_FUNCTION
 bool normal_intersects_segment(const Omega_h::Few<double, 2> a, const Omega_h::Few<double, 2> b, const Omega_h::Few<double, 2> c)
 {
   const auto ab_len = Omega_h::norm(a - b);

--- a/src/pcms/point_search.cpp
+++ b/src/pcms/point_search.cpp
@@ -329,6 +329,14 @@ Kokkos::View<GridPointSearch::Result*> GridPointSearch::operator()(Kokkos::View<
           distance_to_nearest = distance_to_ac;
           parametric_coords_to_nearest = parametric_coords;
         }
+      } else {
+        for (const auto vertex: vertex_coords) {
+          if (const auto distance = Omega_h::norm(point - vertex);distance < distance_to_nearest) {
+           nearest_triange = i;
+           distance_to_nearest = distance;
+           parametric_coords_to_nearest = parametric_coords;
+         }
+        }
       }
 
      if (Omega_h::is_barycentric_inside(parametric_coords, fuzz)) {

--- a/src/pcms/point_search.h
+++ b/src/pcms/point_search.h
@@ -33,6 +33,14 @@ class GridPointSearch
 public:
   static constexpr auto dim = 2;
   struct Result {
+    enum class Dimensionality
+    {
+      VERTEX = 0,
+      EDGE = 1,
+      FACE = 2
+    };
+
+    Dimensionality dimensionality;
     LO tri_id;
     Omega_h::Vector<dim + 1> parametric_coords;
   };

--- a/src/pcms/point_search.h
+++ b/src/pcms/point_search.h
@@ -57,6 +57,9 @@ public:
 
 private:
   Omega_h::Mesh mesh_;
+  Omega_h::Adj tris2edges_adj_;
+  Omega_h::Adj tris2verts_adj_;
+  Omega_h::Adj edges2verts_adj_;
   Kokkos::View<UniformGrid[1]> grid_{"uniform grid"};
   CandidateMapT candidate_map_;
   Omega_h::LOs tris2verts_;

--- a/test/test_point_search.cpp
+++ b/test/test_point_search.cpp
@@ -165,7 +165,7 @@ TEST_CASE("uniform grid search") {
   auto mesh =
     Omega_h::build_box(world, OMEGA_H_SIMPLEX, 1, 1, 1, 10, 10, 0, false);
   GridPointSearch search{mesh,10,10};
-  Kokkos::View<pcms::Real*[2]> points("test_points", 5);
+  Kokkos::View<pcms::Real*[2]> points("test_points", 7);
   //Kokkos::View<pcms::Real*[2]> points("test_points", 1);
   auto points_h = Kokkos::create_mirror_view(points);
   points_h(0,0) = 0;
@@ -178,6 +178,10 @@ TEST_CASE("uniform grid search") {
   points_h(3,1) = 1;
   points_h(4,0) = -1;
   points_h(4,1) = -1;
+  points_h(5, 0) = 1.01;
+  points_h(5, 1) = 0.95;
+  points_h(6, 0) = 0.05;
+  points_h(6, 1) = -0.01;
   Kokkos::deep_copy(points, points_h);
   auto results = search(points);
   auto results_h = Kokkos::create_mirror_view(results);
@@ -186,6 +190,7 @@ TEST_CASE("uniform grid search") {
   {
     {
       auto [dim, idx,coords] = results_h(0);
+      REQUIRE(dim == GridPointSearch::Result::Dimensionality::FACE);
       REQUIRE(idx == 0);
       REQUIRE(coords[0] == Catch::Approx(1));
       REQUIRE(coords[1] == Catch::Approx(0));
@@ -193,6 +198,7 @@ TEST_CASE("uniform grid search") {
     }
     {
       auto [dim, idx,coords] = results_h(1);
+      REQUIRE(dim == GridPointSearch::Result::Dimensionality::FACE);
       REQUIRE(idx == 91);
       REQUIRE(coords[0] == Catch::Approx(0.5));
       REQUIRE(coords[1] == Catch::Approx(0.1));
@@ -200,14 +206,25 @@ TEST_CASE("uniform grid search") {
     }
   }
   // feature needs to be added
-  SECTION("Global coordinate outisde mesh", "[!mayfail]") {
+  SECTION("Global coordinate outside mesh", "[!mayfail]") {
     auto out_of_bounds = results_h(2);
     auto top_right = results_h(3);
     REQUIRE(out_of_bounds.dimensionality == GridPointSearch::Result::Dimensionality::VERTEX);
     REQUIRE(-1*out_of_bounds.tri_id == top_right.tri_id);
+
     out_of_bounds = results_h(4);
     auto bot_left = results_h(0);
     REQUIRE(out_of_bounds.dimensionality == GridPointSearch::Result::Dimensionality::VERTEX);
     REQUIRE(-1*out_of_bounds.tri_id == bot_left.tri_id);
+
+    out_of_bounds = results_h(5);
+    REQUIRE(out_of_bounds.dimensionality ==
+            GridPointSearch::Result::Dimensionality::EDGE);
+    REQUIRE(-1 * out_of_bounds.tri_id == top_right.tri_id);
+
+    out_of_bounds = results_h(6);
+    REQUIRE(out_of_bounds.dimensionality ==
+            GridPointSearch::Result::Dimensionality::EDGE);
+    REQUIRE(-1 * out_of_bounds.tri_id == bot_left.tri_id);
   }
 }

--- a/test/test_point_search.cpp
+++ b/test/test_point_search.cpp
@@ -202,8 +202,8 @@ TEST_CASE("uniform grid search") {
   // feature needs to be added
   SECTION("Global coordinate outisde mesh", "[!mayfail]") {
     auto out_of_bounds = results_h(2);
-    auto top_left = results_h(3);
-    REQUIRE(-1*out_of_bounds.tri_id == top_left.tri_id);
+    auto top_right = results_h(3);
+    REQUIRE(-1*out_of_bounds.tri_id == top_right.tri_id);
     out_of_bounds = results_h(4);
     auto bot_left = results_h(0);
     REQUIRE(-1*out_of_bounds.tri_id == bot_left.tri_id);

--- a/test/test_point_search.cpp
+++ b/test/test_point_search.cpp
@@ -185,14 +185,14 @@ TEST_CASE("uniform grid search") {
   SECTION("global coordinate within mesh")
   {
     {
-      auto [idx,coords] = results_h(0);
+      auto [dim, idx,coords] = results_h(0);
       REQUIRE(idx == 0);
       REQUIRE(coords[0] == Catch::Approx(1));
       REQUIRE(coords[1] == Catch::Approx(0));
       REQUIRE(coords[2] == Catch::Approx(0));
     }
     {
-      auto [idx,coords] = results_h(1);
+      auto [dim, idx,coords] = results_h(1);
       REQUIRE(idx == 91);
       REQUIRE(coords[0] == Catch::Approx(0.5));
       REQUIRE(coords[1] == Catch::Approx(0.1));
@@ -203,9 +203,11 @@ TEST_CASE("uniform grid search") {
   SECTION("Global coordinate outisde mesh", "[!mayfail]") {
     auto out_of_bounds = results_h(2);
     auto top_right = results_h(3);
+    REQUIRE(out_of_bounds.dimensionality == GridPointSearch::Result::Dimensionality::VERTEX);
     REQUIRE(-1*out_of_bounds.tri_id == top_right.tri_id);
     out_of_bounds = results_h(4);
     auto bot_left = results_h(0);
+    REQUIRE(out_of_bounds.dimensionality == GridPointSearch::Result::Dimensionality::VERTEX);
     REQUIRE(-1*out_of_bounds.tri_id == bot_left.tri_id);
   }
 }

--- a/test/test_point_search.cpp
+++ b/test/test_point_search.cpp
@@ -200,12 +200,12 @@ TEST_CASE("uniform grid search") {
     }
   }
   // feature needs to be added
-  //SECTION("Global coordinate outisde mesh", "[!mayfail]") {
-  //  auto out_of_bounds = results_h(2);
-  //  auto top_left = results_h(3);
-  //  REQUIRE(-1*out_of_bounds.tri_id == top_left.tri_id);
-  //  out_of_bounds = results_h(4);
-  //  auto bot_left = results_h(0);
-  //  REQUIRE(-1*out_of_bounds.tri_id == bot_left.tri_id);
-  //}
+  SECTION("Global coordinate outisde mesh", "[!mayfail]") {
+    auto out_of_bounds = results_h(2);
+    auto top_left = results_h(3);
+    REQUIRE(-1*out_of_bounds.tri_id == top_left.tri_id);
+    out_of_bounds = results_h(4);
+    auto bot_left = results_h(0);
+    REQUIRE(-1*out_of_bounds.tri_id == bot_left.tri_id);
+  }
 }


### PR DESCRIPTION
This pull request introduces several important changes to the `pcms` module, specifically focusing on the `omega_h_field` and `point_search` components. The changes include the addition of a new functor for owned mask computation, enhancements to the `GridPointSearch` class, and updates to the associated test cases.

### Enhancements to `omega_h_field`:

* Added `OwnedMaskFunctor` struct to encapsulate the logic for computing the owned mask, improving code readability and maintainability. (`src/pcms/omega_h_field.h`, [src/pcms/omega_h_field.hR99-R122](diffhunk://#diff-d0fe46671ffb68586cb64d24501146105ff23e3fed16fddd57ef73a768fe2e30R99-R122))
* Refactored the `OmegaHFieldAdapter` class to use the new `OwnedMaskFunctor` for parallel computation of the owned mask. (`src/pcms/omega_h_field.h`, [src/pcms/omega_h_field.hL456-R481](diffhunk://#diff-d0fe46671ffb68586cb64d24501146105ff23e3fed16fddd57ef73a768fe2e30L456-R481))

### Enhancements to `point_search`:

* Introduced new utility functions `distance_from_line`, `angle_from_side_lengths`, and `normal_intersects_segment` to support geometric calculations. (`src/pcms/point_search.cpp`, [src/pcms/point_search.cppR5-R35](diffhunk://#diff-b6ad98d142d76056630fef89bd0d6d47d7f0dfb5b7944b7937c9410f08d479d0R5-R35))
* Enhanced the `GridPointSearch` class to include additional adjacency information (`tris2edges_adj`, `tris2verts_adj`, `edges2verts_adj`) and updated the `operator()` method to utilize these for improved point search accuracy. (`src/pcms/point_search.cpp`, [[1]](diffhunk://#diff-b6ad98d142d76056630fef89bd0d6d47d7f0dfb5b7944b7937c9410f08d479d0R270-R272) [[2]](diffhunk://#diff-b6ad98d142d76056630fef89bd0d6d47d7f0dfb5b7944b7937c9410f08d479d0R281-R350) [[3]](diffhunk://#diff-b6ad98d142d76056630fef89bd0d6d47d7f0dfb5b7944b7937c9410f08d479d0R369-R371)
* Updated the `GridPointSearch::Result` struct to include a new `Dimensionality` enum, allowing results to specify whether a point is closest to a vertex, edge, or face. (`src/pcms/point_search.h`, [[1]](diffhunk://#diff-2ecd0755f40bfb74a7216b8c61a8778312ec405396f82f190f03390b61add67dR36-R43) [[2]](diffhunk://#diff-2ecd0755f40bfb74a7216b8c61a8778312ec405396f82f190f03390b61add67dR60-R62)

### Updates to test cases:

* Expanded the test points in the `TEST_CASE("uniform grid search")` to include additional scenarios for points outside the mesh. (`test/test_point_search.cpp`, [[1]](diffhunk://#diff-e467d59b116c1d13e0f7604011f0cf481b532ddd68ee2f2f674f35d8d9fd22caL168-R168) [[2]](diffhunk://#diff-e467d59b116c1d13e0f7604011f0cf481b532ddd68ee2f2f674f35d8d9fd22caR181-R229)
* Enhanced test assertions to check the new `Dimensionality` field in the `GridPointSearch::Result` struct, ensuring correctness of the updated point search logic. (`test/test_point_search.cpp`, [test/test_point_search.cppR181-R229](diffhunk://#diff-e467d59b116c1d13e0f7604011f0cf481b532ddd68ee2f2f674f35d8d9fd22caR181-R229))