### PR TITLE
2D Tolerance Search and N-Dimension Uniform Grid

### DIFF
--- a/src/pcms/adapter/omega_h/omega_h_field.h
+++ b/src/pcms/adapter/omega_h/omega_h_field.h
@@ -153,14 +153,13 @@ public:
   void ConstructSearch(int nx, int ny)
   {
     PCMS_FUNCTION_TIMER;
-    search_ = GridPointSearch2D(mesh_, nx, ny);
+    search_ = std::make_unique<GridPointSearch2D>(mesh_, nx, ny);
   }
   // pass through to search function
   [[nodiscard]] auto Search(Kokkos::View<Real* [2]> points) const
   {
     PCMS_FUNCTION_TIMER;
-    PCMS_ALWAYS_ASSERT(search_.has_value() &&
-                       "search data structure must be constructed before use");
+    PCMS_ALWAYS_ASSERT(search_ != nullptr && "search data structure must be constructed before use");
     return (*search_)(points);
   }
 
@@ -220,7 +219,7 @@ private:
   std::string name_;
   Omega_h::Mesh& mesh_;
   // TODO make this a pointer and introduce base class to Search for alternative search methods
-  std::optional<GridPointSearch2D> search_;
+  std::unique_ptr<PointLocalizationSearch2D> search_;
   // bitmask array that specifies a filter on the field
   Omega_h::Read<LO> mask_;
   LO size_;

--- a/src/pcms/adapter/omega_h/omega_h_field.h
+++ b/src/pcms/adapter/omega_h/omega_h_field.h
@@ -153,7 +153,7 @@ public:
   void ConstructSearch(int nx, int ny)
   {
     PCMS_FUNCTION_TIMER;
-    search_ = GridPointSearch(mesh_, nx, ny);
+    search_ = GridPointSearch2D(mesh_, nx, ny);
   }
   // pass through to search function
   [[nodiscard]] auto Search(Kokkos::View<Real* [2]> points) const
@@ -219,9 +219,8 @@ public:
 private:
   std::string name_;
   Omega_h::Mesh& mesh_;
-  // TODO make this a pointer and introduce base class to Search for alternative
-  // search methods
-  std::optional<GridPointSearch> search_;
+  // TODO make this a pointer and introduce base class to Search for alternative search methods
+  std::optional<GridPointSearch2D> search_;
   // bitmask array that specifies a filter on the field
   Omega_h::Read<LO> mask_;
   LO size_;

--- a/src/pcms/interpolator/adj_search.hpp
+++ b/src/pcms/interpolator/adj_search.hpp
@@ -30,8 +30,8 @@ inline void checkTargetPoints(
   printf("INFO: Checking target points...\n");
   auto check_target_points = OMEGA_H_LAMBDA(Omega_h::LO i)
   {
-    if (results(i).tri_id < 0) {
-      OMEGA_H_CHECK_PRINTF(results(i).tri_id >= 0,
+    if (results(i).element_id < 0) {
+      OMEGA_H_CHECK_PRINTF(results(i).element_id >= 0,
                            "ERROR: Source cell id not found for target %d\n",
                            i);
       printf("%d, ", i);
@@ -129,7 +129,7 @@ inline void FindSupports::adjBasedSearch(
       Track visited;
       Omega_h::Real cutoffDistance = radii2[id];
 
-      Omega_h::LO source_cell_id = results(id).tri_id;
+      Omega_h::LO source_cell_id = results(id).element_id;
       OMEGA_H_CHECK_PRINTF(
         source_cell_id >= 0,
         "ERROR: Source cell id not found for target %d (%f,%f)\n", id,

--- a/src/pcms/interpolator/adj_search.hpp
+++ b/src/pcms/interpolator/adj_search.hpp
@@ -24,7 +24,7 @@ Omega_h::Real calculateDistance(const Omega_h::Real* p1,
 }
 
 inline void checkTargetPoints(
-  const Kokkos::View<pcms::GridPointSearch::Result*>& results)
+  const Kokkos::View<pcms::GridPointSearch2D::Result*>& results)
 {
   Kokkos::fence();
   printf("INFO: Checking target points...\n");
@@ -118,7 +118,7 @@ inline void FindSupports::adjBasedSearch(
     });
   Kokkos::fence();
 
-  pcms::GridPointSearch search_cell(source_mesh, 10, 10);
+  pcms::GridPointSearch2D search_cell(source_mesh, 10, 10);
   auto results = search_cell(target_points);
   checkTargetPoints(results);
 

--- a/src/pcms/point_search.cpp
+++ b/src/pcms/point_search.cpp
@@ -476,12 +476,12 @@ Kokkos::View<GridPointSearch2D::Result*> GridPointSearch2D::operator()(Kokkos::V
 }
 
 GridPointSearch2D::GridPointSearch2D(Omega_h::Mesh& mesh, LO Nx, LO Ny)
-  : GridPointSearch2D(mesh, Nx, Ny, { })
+  : GridPointSearch2D(mesh, Nx, Ny, PointSearchTolerances { "point search 2d tolerances" })
 {
   Kokkos::deep_copy(tolerances_, 0);
 }
 
-GridPointSearch2D::GridPointSearch2D(Omega_h::Mesh& mesh, LO Nx, LO Ny, PointSearchTolerances tolerances)
+GridPointSearch2D::GridPointSearch2D(Omega_h::Mesh& mesh, LO Nx, LO Ny, const PointSearchTolerances& tolerances)
   : PointLocalizationSearch(tolerances)
 {
   auto mesh_bbox = Omega_h::get_bounding_box<2>(&mesh);
@@ -554,6 +554,14 @@ Kokkos::View<GridPointSearch3D::Result*> GridPointSearch3D::operator()(Kokkos::V
 }
 
 GridPointSearch3D::GridPointSearch3D(Omega_h::Mesh& mesh, LO Nx, LO Ny, LO Nz)
+  : GridPointSearch3D(mesh, Nx, Ny, Nz,  PointSearchTolerances { "point search 3d tolerances" })
+{
+  Kokkos::deep_copy(tolerances_, 0);
+}
+
+GridPointSearch3D::GridPointSearch3D(Omega_h::Mesh& mesh, LO Nx, LO Ny, LO Nz,
+                                     const PointSearchTolerances& tolerances)
+                                       : PointLocalizationSearch(tolerances)
 {
   auto mesh_bbox = Omega_h::get_bounding_box<3>(&mesh);
   auto grid_h = Kokkos::create_mirror_view(grid_);

--- a/src/pcms/point_search.cpp
+++ b/src/pcms/point_search.cpp
@@ -188,7 +188,7 @@ template <int dim>
   // each dimension has a pair of opposing "walls"
   // 2D: { [left, right], [top, bottom] } -> { left, right, top, bottom }
   // 3D: { [left, right], [top, bottom], [front, back] } -> { left, ..., back }
-  std::array<Real, dim * 2> bbox_walls{};
+  std::array<Real, dim * 2ul> bbox_walls{};
   for (int i = 0; i < dim; i++) {
     bbox_walls[i * 2] = bbox.center[i] - bbox.half_width[i];
     bbox_walls[i * 2 + 1] = bbox.center[i] + bbox.half_width[i];

--- a/src/pcms/point_search.cpp
+++ b/src/pcms/point_search.cpp
@@ -2,29 +2,35 @@
 #include <Omega_h_mesh.hpp>
 #include <bitset>
 
-// From https://en.wikipedia.org/wiki/Distance_from_a_point_to_a_line#Line_defined_by_two_points
+// From
+// https://en.wikipedia.org/wiki/Distance_from_a_point_to_a_line#Line_defined_by_two_points
 KOKKOS_INLINE_FUNCTION
-double distance_from_line(const double x0, const double y0, const double x1, const double y1, const double x2, const double y2)
+double distance_from_line(const double x0, const double y0, const double x1,
+                          const double y1, const double x2, const double y2)
 {
-  const Omega_h::Vector<2> p1 = { x1, y1 };
-  const Omega_h::Vector<2> p2 = { x2, y2 };
+  const Omega_h::Vector<2> p1 = {x1, y1};
+  const Omega_h::Vector<2> p2 = {x2, y2};
   auto disp = p2 - p1;
 
-  return std::abs(disp[1]*x0 - disp[0]*y0 + x2*y1 - y2*x1) / Omega_h::norm(disp);
+  return std::abs(disp[1] * x0 - disp[0] * y0 + x2 * y1 - y2 * x1) /
+         Omega_h::norm(disp);
 }
 
-// Law of Cosines, where a, b, c and gamma are defined here: https://en.wikipedia.org/wiki/Law_of_cosines#Use_in_solving_triangles
+// Law of Cosines, where a, b, c and gamma are defined here:
+// https://en.wikipedia.org/wiki/Law_of_cosines#Use_in_solving_triangles
 KOKKOS_INLINE_FUNCTION
 double angle_from_side_lengths(const double a, const double b, const double c)
 {
-  return std::acos((a*a + b*b - c*c) / 2*a*b);
+  return std::acos((a * a + b * b - c * c) / 2 * a * b);
 }
 
 KOKKOS_INLINE_FUNCTION
-bool normal_intersects_segment(const Omega_h::Few<double, 2> a, const Omega_h::Few<double, 2> b, const Omega_h::Few<double, 2> c)
+bool normal_intersects_segment(const Omega_h::Few<double, 2> a,
+                               const Omega_h::Few<double, 2> b,
+                               const Omega_h::Few<double, 2> c)
 {
   const auto ab_len = Omega_h::norm(a - b);
-  const auto bc_len = Omega_h::norm(b -c);
+  const auto bc_len = Omega_h::norm(b - c);
   const auto ac_len = Omega_h::norm(a - c);
 
   const double angle1 = angle_from_side_lengths(bc_len, ac_len, ab_len);
@@ -137,40 +143,52 @@ bool line_intersects_bbox(const Omega_h::Vector<2>& p0,
 }
 
 template <unsigned dim>
-[[nodiscard]] KOKKOS_INLINE_FUNCTION
-bool within_bbox(const Omega_h::Vector<dim> coord, const AABBox<dim> & bbox) noexcept {
+[[nodiscard]] KOKKOS_INLINE_FUNCTION bool within_bbox(
+  const Omega_h::Vector<dim> coord, const AABBox<dim>& bbox) noexcept
+{
   for (int i = 0; i < dim; ++i) {
-    if (coord[i] < bbox.center[i] - bbox.half_width[i]) return false;
-    if (coord[i] > bbox.center[i] + bbox.half_width[i]) return false;
+    if (coord[i] < bbox.center[i] - bbox.half_width[i])
+      return false;
+    if (coord[i] > bbox.center[i] + bbox.half_width[i])
+      return false;
   }
   return true;
 }
 
-[[nodiscard]] KOKKOS_INLINE_FUNCTION
-bool bbox_verts_within_triangle(const AABBox<2>& bbox, const Omega_h::Matrix<2,3>& coords) {
+[[nodiscard]] KOKKOS_INLINE_FUNCTION bool bbox_verts_within_triangle(
+  const AABBox<2>& bbox, const Omega_h::Matrix<2, 3>& coords)
+{
   auto left = bbox.center[0] - bbox.half_width[0];
   auto right = bbox.center[0] + bbox.half_width[0];
   auto bot = bbox.center[1] - bbox.half_width[1];
   auto top = bbox.center[1] + bbox.half_width[1];
-  auto xi = Omega_h::barycentric_from_global<2, 2>({left,bot}, coords);
-  if(Omega_h::is_barycentric_inside(xi, fuzz)){ return true;}
-  xi = Omega_h::barycentric_from_global<2, 2>({left,top}, coords);
-  if(Omega_h::is_barycentric_inside(xi, fuzz)){ return true;}
-  xi = Omega_h::barycentric_from_global<2, 2>({right,top}, coords);
-  if(Omega_h::is_barycentric_inside(xi, fuzz)){ return true;}
-  xi = Omega_h::barycentric_from_global<2, 2>({right,bot}, coords);
-  if(Omega_h::is_barycentric_inside(xi, fuzz)){ return true;}
+  auto xi = Omega_h::barycentric_from_global<2, 2>({left, bot}, coords);
+  if (Omega_h::is_barycentric_inside(xi, fuzz)) {
+    return true;
+  }
+  xi = Omega_h::barycentric_from_global<2, 2>({left, top}, coords);
+  if (Omega_h::is_barycentric_inside(xi, fuzz)) {
+    return true;
+  }
+  xi = Omega_h::barycentric_from_global<2, 2>({right, top}, coords);
+  if (Omega_h::is_barycentric_inside(xi, fuzz)) {
+    return true;
+  }
+  xi = Omega_h::barycentric_from_global<2, 2>({right, bot}, coords);
+  if (Omega_h::is_barycentric_inside(xi, fuzz)) {
+    return true;
+  }
   return false;
 }
 
 template <int dim>
-[[nodiscard]] KOKKOS_INLINE_FUNCTION
-bool bbox_verts_within_simplex(const AABBox<dim>& bbox, const Omega_h::Matrix<dim,dim+1>& coords)
+[[nodiscard]] KOKKOS_INLINE_FUNCTION bool bbox_verts_within_simplex(
+  const AABBox<dim>& bbox, const Omega_h::Matrix<dim, dim + 1>& coords)
 {
   // each dimension has a pair of opposing "walls"
   // 2D: { [left, right], [top, bottom] } -> { left, right, top, bottom }
   // 3D: { [left, right], [top, bottom], [front, back] } -> { left, ..., back }
-  std::array<Real, dim * 2> bbox_walls {};
+  std::array<Real, dim * 2> bbox_walls{};
   for (int i = 0; i < dim; i++) {
     bbox_walls[i * 2] = bbox.center[i] - bbox.half_width[i];
     bbox_walls[i * 2 + 1] = bbox.center[i] + bbox.half_width[i];
@@ -202,15 +220,13 @@ bool bbox_verts_within_simplex(const AABBox<dim>& bbox, const Omega_h::Matrix<di
  * intersects with a bounding box
  */
 [[nodiscard]]
-KOKKOS_FUNCTION
-bool triangle_intersects_bbox(const Omega_h::Matrix<2, 3>& coords,
-                                            const AABBox<2>& bbox)
+KOKKOS_FUNCTION bool triangle_intersects_bbox(
+  const Omega_h::Matrix<2, 3>& coords, const AABBox<2>& bbox)
 {
   // triangle and grid cell bounding box intersect
   if (intersects(triangle_bbox(coords), bbox)) {
     // if any of the triangle verts inside of bbox
-    if (within_bbox<2>(coords[0], bbox) ||
-        within_bbox<2>(coords[1], bbox) ||
+    if (within_bbox<2>(coords[0], bbox) || within_bbox<2>(coords[1], bbox) ||
         within_bbox<2>(coords[2], bbox)) {
       return true;
     }
@@ -230,8 +246,8 @@ bool triangle_intersects_bbox(const Omega_h::Matrix<2, 3>& coords,
 
 template <unsigned dim>
 [[nodiscard]]
-KOKKOS_FUNCTION
-bool simplex_intersects_bbox(const Omega_h::Matrix<dim, dim + 1>& coords, const AABBox<dim>& bbox)
+KOKKOS_FUNCTION bool simplex_intersects_bbox(
+  const Omega_h::Matrix<dim, dim + 1>& coords, const AABBox<dim>& bbox)
 {
   return intersects(simplex_bbox<dim>(coords), bbox);
   // TODO: Add refined cases from triangle_intersects_bbox
@@ -251,7 +267,8 @@ namespace detail
  */
 struct GridTriIntersectionFunctor2D
 {
-  GridTriIntersectionFunctor2D(Omega_h::Mesh& mesh, Kokkos::View<Uniform2DGrid[1]> grid)
+  GridTriIntersectionFunctor2D(Omega_h::Mesh& mesh,
+                               Kokkos::View<Uniform2DGrid[1]> grid)
     : mesh_(mesh),
       tris2verts_(mesh_.ask_elem_verts()),
       coords_(mesh_.coords()),
@@ -274,9 +291,11 @@ struct GridTriIntersectionFunctor2D
     LO num_intersections = 0;
     // hierarchical parallel may make be very beneficial here...
     for (LO elem_idx = 0; elem_idx < nelems_; ++elem_idx) {
-      const auto elem_tri2verts = Omega_h::gather_verts<3>(tris2verts_, elem_idx);
+      const auto elem_tri2verts =
+        Omega_h::gather_verts<3>(tris2verts_, elem_idx);
       // 2d mesh with 2d coords, but 3 triangles
-      const auto vertex_coords = Omega_h::gather_vectors<3, 2>(coords_, elem_tri2verts);
+      const auto vertex_coords =
+        Omega_h::gather_vectors<3, 2>(coords_, elem_tri2verts);
       if (triangle_intersects_bbox(vertex_coords, grid_cell_bbox)) {
         if (fill) {
           fill[num_intersections] = elem_idx;
@@ -292,13 +311,15 @@ private:
   Omega_h::LOs tris2verts_;
   Omega_h::Reals coords_;
   Kokkos::View<Uniform2DGrid[1]> grid_;
+
 public:
   LO nelems_;
 };
 
 struct GridTriIntersectionFunctor3D
 {
-  GridTriIntersectionFunctor3D(Omega_h::Mesh& mesh, Kokkos::View<Uniform3DGrid[1]> grid)
+  GridTriIntersectionFunctor3D(Omega_h::Mesh& mesh,
+                               Kokkos::View<Uniform3DGrid[1]> grid)
     : mesh_(mesh),
       tets2verts_(mesh_.ask_elem_verts()),
       coords_(mesh_.coords()),
@@ -321,8 +342,10 @@ struct GridTriIntersectionFunctor3D
     LO num_intersections = 0;
     // hierarchical parallel may make be very beneficial here...
     for (LO elem_idx = 0; elem_idx < nelems_; ++elem_idx) {
-      const auto elem_tet2verts = Omega_h::gather_verts<4>(tets2verts_, elem_idx);
-      const auto vertex_coords = Omega_h::gather_vectors<4, 3>(coords_, elem_tet2verts);
+      const auto elem_tet2verts =
+        Omega_h::gather_verts<4>(tets2verts_, elem_idx);
+      const auto vertex_coords =
+        Omega_h::gather_vectors<4, 3>(coords_, elem_tet2verts);
       if (simplex_intersects_bbox<3>(vertex_coords, grid_cell_bbox)) {
         if (fill) {
           fill[num_intersections] = elem_idx;
@@ -338,14 +361,17 @@ private:
   Omega_h::LOs tets2verts_;
   Omega_h::Reals coords_;
   Kokkos::View<Uniform3DGrid[1]> grid_;
+
 public:
   LO nelems_;
 };
 
-// num_grid_cells should be result of grid.GetNumCells(), take as argument to avoid extra copy
-// of grid from gpu to cpu
+// num_grid_cells should be result of grid.GetNumCells(), take as argument to
+// avoid extra copy of grid from gpu to cpu
 Kokkos::Crs<LO, Kokkos::DefaultExecutionSpace, void, LO>
-construct_intersection_map_2d(Omega_h::Mesh& mesh, Kokkos::View<Uniform2DGrid[1]> grid, int num_grid_cells)
+construct_intersection_map_2d(Omega_h::Mesh& mesh,
+                              Kokkos::View<Uniform2DGrid[1]> grid,
+                              int num_grid_cells)
 {
   Kokkos::Crs<LO, Kokkos::DefaultExecutionSpace, void, LO> intersection_map{};
   auto f = detail::GridTriIntersectionFunctor2D{mesh, grid};
@@ -354,7 +380,9 @@ construct_intersection_map_2d(Omega_h::Mesh& mesh, Kokkos::View<Uniform2DGrid[1]
 }
 
 Kokkos::Crs<LO, Kokkos::DefaultExecutionSpace, void, LO>
-construct_intersection_map_3d(Omega_h::Mesh& mesh, Kokkos::View<Uniform3DGrid[1]> grid, int num_grid_cells)
+construct_intersection_map_3d(Omega_h::Mesh& mesh,
+                              Kokkos::View<Uniform3DGrid[1]> grid,
+                              int num_grid_cells)
 {
   Kokkos::Crs<LO, Kokkos::DefaultExecutionSpace, void, LO> intersection_map{};
   auto f = detail::GridTriIntersectionFunctor3D{mesh, grid};
@@ -363,158 +391,21 @@ construct_intersection_map_3d(Omega_h::Mesh& mesh, Kokkos::View<Uniform3DGrid[1]
 }
 } // namespace detail
 
-template <int n,  typename Op>
-OMEGA_H_INLINE double myreduce(const Omega_h::Vector<n> & x, Op op) OMEGA_H_NOEXCEPT {
+template <int n, typename Op>
+OMEGA_H_INLINE double myreduce(const Omega_h::Vector<n>& x,
+                               Op op) OMEGA_H_NOEXCEPT
+{
   auto out = x[0];
-  for (int i = 1; i < n; ++i) out = op(out, x[i]);
+  for (int i = 1; i < n; ++i)
+    out = op(out, x[i]);
   return out;
-}         
-
-Kokkos::View<GridPointSearch2D::Result*> GridPointSearch2D::operator()(Kokkos::View<Real*[DIM] > points) const
-{
-  Kokkos::View<GridPointSearch2D::Result*> results("point search result", points.extent(0));
-  auto num_rows = candidate_map_.numRows();
-  // needed so that we don't capture this ptr which will be memory error on cuda
-  auto grid = grid_; 
-  auto candidate_map = candidate_map_;
-  auto tris2verts = tris2verts_;
-  auto tris2verts_adj = tris2verts_adj_;
-  auto tris2edges_adj = tris2edges_adj_;
-  auto edges2verts_adj = edges2verts_adj_;
-  auto coords = coords_;
-  auto tolerances = tolerances_;
-  Kokkos::parallel_for(points.extent(0), KOKKOS_LAMBDA(int p) {
-    Omega_h::Vector<2> point(std::initializer_list<double>{points(p,0), points(p,1)});
-    auto cell_id = grid(0).ClosestCellID(point);
-    assert(cell_id < num_rows && cell_id >= 0);
-    auto candidates_begin = candidate_map.row_map(cell_id);
-    auto candidates_end = candidate_map.row_map(cell_id + 1);
-
-    bool vertex_found = false;
-    bool edge_found = false;
-    bool inside_cell = false;
-
-    auto nearest_element_id = candidates_begin;
-    auto dimensionality = GridPointSearch2D::Result::Dimensionality::REGION;
-    Omega_h::Real distance_to_nearest { INFINITY };
-    Omega_h::Vector<3> parametric_coords_to_nearest;
-    // create array that's size of number of candidates x num coords to store
-    // parametric inversion
-    for (auto i = candidates_begin; i < candidates_end; ++i) {
-      const int triangleID = candidate_map.entries(i);
-      const auto elem_tri2verts = Omega_h::gather_verts<3>(tris2verts, triangleID);
-      // 2d mesh with 2d coords, but 3 triangles
-      auto vertex_coords = Omega_h::gather_vectors<3, 2>(coords, elem_tri2verts);
-      auto parametric_coords = Omega_h::barycentric_from_global<2, 2>(point, vertex_coords);
-
-      // Every triangle (face) is connected to 3 vertices
-      for (int j = 0; j < 3; ++j) {
-        // Get the vertex ID from the connectivity array
-        const int vertexID = tris2verts_adj.ab2b[triangleID * 3 + j];
-        // Get the vertex coordinates from the mesh using vertexID
-        const Omega_h::Few<double, 2> vertex =
-          Omega_h::get_vector<2>(coords, vertexID);
-
-        const auto distance = Omega_h::norm(point - vertex);
-
-        if (distance < distance_to_nearest) {
-          dimensionality = GridPointSearch2D::Result::Dimensionality::VERTEX;
-          nearest_element_id = vertexID;
-          distance_to_nearest = distance;
-          parametric_coords_to_nearest = parametric_coords;
-
-          if (distance < tolerances(0)) {
-            vertex_found = true;
-          };
-        }
-      }
-
-      if (vertex_found)
-        break;
-
-      for (int j = 0; j < 3; ++j) {
-        // Every triangle (face) is connected to 3 edges
-        const int edgeID = tris2edges_adj.ab2b[triangleID * 3 + j];
-
-        auto vertex_a_id = edges2verts_adj.ab2b[edgeID * 2];
-        auto vertex_b_id = edges2verts_adj.ab2b[edgeID * 2 + 1];
-
-        auto vertex_a = Omega_h::get_vector<2>(coords, vertex_a_id);
-        auto vertex_b = Omega_h::get_vector<2>(coords, vertex_b_id);
-
-        if (!normal_intersects_segment(point, vertex_a, vertex_b))
-          continue;
-
-        const auto xa = vertex_a[0];
-        const auto ya = vertex_a[1];
-        const auto xb = vertex_b[0];
-        const auto yb = vertex_b[1];
-
-        const auto xp = point[0];
-        const auto yp = point[1];
-
-        const auto distance_to_ab = distance_from_line(xp, yp, xa, ya, xb, yb);
-
-        if (distance_to_ab < distance_to_nearest) {
-          dimensionality = GridPointSearch2D::Result::Dimensionality::EDGE;
-          nearest_element_id = edgeID;
-          distance_to_nearest = distance_to_ab;
-          parametric_coords_to_nearest = parametric_coords;
-
-          if (distance_to_ab < tolerances(1)) {
-            edge_found = true;
-          };
-        }
-      }
-
-      if (edge_found)
-        break;
-
-      if (Omega_h::is_barycentric_inside(parametric_coords, fuzz)) {
-        dimensionality = GridPointSearch2D::Result::Dimensionality::FACE;
-        nearest_element_id = triangleID;
-        parametric_coords_to_nearest = parametric_coords;
-        inside_cell = true;
-
-        // results(p) = GridPointSearch2D::Result{GridPointSearch2D::Result::Dimensionality::FACE, triangleID, parametric_coords};
-        // return;
-      }
-    }
-
-    const int inside_mesh = vertex_found || edge_found || inside_cell ? 1 : -1;
-    results(p) = GridPointSearch2D::Result{dimensionality, inside_mesh * nearest_element_id, parametric_coords_to_nearest};
-  });
-
-  return results;
 }
 
-GridPointSearch2D::GridPointSearch2D(Omega_h::Mesh& mesh, LO Nx, LO Ny)
-  : GridPointSearch2D(mesh, Nx, Ny, PointSearchTolerances { "point search 2d tolerances" })
+Kokkos::View<GridPointSearch2D::Result*> GridPointSearch2D::operator()(
+  Kokkos::View<Real* [DIM]> points) const
 {
-  Kokkos::deep_copy(tolerances_, 0);
-}
-
-GridPointSearch2D::GridPointSearch2D(Omega_h::Mesh& mesh, LO Nx, LO Ny, const PointSearchTolerances& tolerances)
-  : PointLocalizationSearch(tolerances)
-{
-  auto mesh_bbox = Omega_h::get_bounding_box<2>(&mesh);
-  auto grid_h = Kokkos::create_mirror_view(grid_);
-  grid_h(0) = Uniform2DGrid{.edge_length = {mesh_bbox.max[0] - mesh_bbox.min[0],
-                           mesh_bbox.max[1] - mesh_bbox.min[1]},
-    .bot_left = {mesh_bbox.min[0], mesh_bbox.min[1]},
-    .divisions = {Nx, Ny}};
-  Kokkos::deep_copy(grid_, grid_h);
-  candidate_map_ = detail::construct_intersection_map_2d(mesh, grid_, grid_h(0).GetNumCells());
-  coords_ = mesh.coords();
-  tris2verts_ = mesh.ask_elem_verts();
-  tris2edges_adj_ = mesh.ask_down(Omega_h::FACE, Omega_h::EDGE);
-  tris2verts_adj_ = mesh.ask_down(Omega_h::FACE, Omega_h::VERT);
-  edges2verts_adj_ = mesh.ask_down(Omega_h::EDGE, Omega_h::VERT);
-}
-
-Kokkos::View<GridPointSearch3D::Result*> GridPointSearch3D::operator()(Kokkos::View<Real*[DIM] > points) const
-{
-  Kokkos::View<GridPointSearch3D::Result*> results("point search result", points.extent(0));
+  Kokkos::View<GridPointSearch2D::Result*> results("point search result",
+                                                   points.extent(0));
   auto num_rows = candidate_map_.numRows();
   // needed so that we don't capture this ptr which will be memory error on cuda
   auto grid = grid_;
@@ -524,77 +415,241 @@ Kokkos::View<GridPointSearch3D::Result*> GridPointSearch3D::operator()(Kokkos::V
   auto tris2edges_adj = tris2edges_adj_;
   auto edges2verts_adj = edges2verts_adj_;
   auto coords = coords_;
-  Kokkos::parallel_for(points.extent(0), KOKKOS_LAMBDA(int p) {
+  auto tolerances = tolerances_;
+  Kokkos::parallel_for(
+    points.extent(0), KOKKOS_LAMBDA(int p) {
+      Omega_h::Vector<2> point(
+        std::initializer_list<double>{points(p, 0), points(p, 1)});
+      auto cell_id = grid(0).ClosestCellID(point);
+      assert(cell_id < num_rows && cell_id >= 0);
+      auto candidates_begin = candidate_map.row_map(cell_id);
+      auto candidates_end = candidate_map.row_map(cell_id + 1);
 
-    Omega_h::Vector<DIM> point;
-    for (int i = 0; i < DIM; ++i) {
-      point[i] = points(p, i);
-    }
+      bool vertex_found = false;
+      bool edge_found = false;
+      bool inside_cell = false;
 
-    auto cell_id = grid(0).ClosestCellID(point);
-    assert(cell_id < num_rows && cell_id >= 0);
-    auto candidates_begin = candidate_map.row_map(cell_id);
-    auto candidates_end = candidate_map.row_map(cell_id + 1);
-    bool found = false;
+      auto nearest_element_id = candidates_begin;
+      auto dimensionality = GridPointSearch2D::Result::Dimensionality::REGION;
+      Omega_h::Real distance_to_nearest{INFINITY};
+      Omega_h::Vector<3> parametric_coords_to_nearest;
+      // create array that's size of number of candidates x num coords to store
+      // parametric inversion
+      for (auto i = candidates_begin; i < candidates_end; ++i) {
+        const int triangleID = candidate_map.entries(i);
+        const auto elem_tri2verts =
+          Omega_h::gather_verts<3>(tris2verts, triangleID);
+        // 2d mesh with 2d coords, but 3 triangles
+        auto vertex_coords =
+          Omega_h::gather_vectors<3, 2>(coords, elem_tri2verts);
+        auto parametric_coords =
+          Omega_h::barycentric_from_global<2, 2>(point, vertex_coords);
 
-    auto nearest_triangle = candidates_begin;
-    auto dimensionality = GridPointSearch3D::Result::Dimensionality::EDGE;
-    Omega_h::Real distance_to_nearest { INFINITY };
-    Omega_h::Vector<DIM + 1> parametric_coords_to_nearest;
-    // create array that's size of number of candidates x num coords to store
-    // parametric inversion
-    for (auto i = candidates_begin; i < candidates_end; ++i) {
-      const int triangleID = candidate_map.entries(i);
-      const auto elem_tri2verts = Omega_h::gather_verts<DIM + 1>(tris2verts, triangleID);
-      auto vertex_coords = Omega_h::gather_vectors<DIM + 1, DIM>(coords, elem_tri2verts);
-      auto parametric_coords = Omega_h::barycentric_from_global<DIM, DIM>(point, vertex_coords);
+        // Every triangle (face) is connected to 3 vertices
+        for (int j = 0; j < 3; ++j) {
+          // Get the vertex ID from the connectivity array
+          const int vertexID = tris2verts_adj.ab2b[triangleID * 3 + j];
+          // Get the vertex coordinates from the mesh using vertexID
+          const Omega_h::Few<double, 2> vertex =
+            Omega_h::get_vector<2>(coords, vertexID);
 
-      if (Omega_h::is_barycentric_inside(parametric_coords, fuzz)) {
-        results(p) = GridPointSearch3D::Result{GridPointSearch3D::Result::Dimensionality::REGION, triangleID, parametric_coords};
-        found = true;
-        break;
+          const auto distance = Omega_h::norm(point - vertex);
+
+          if (distance < distance_to_nearest) {
+            dimensionality = GridPointSearch2D::Result::Dimensionality::VERTEX;
+            nearest_element_id = vertexID;
+            distance_to_nearest = distance;
+            parametric_coords_to_nearest = parametric_coords;
+
+            if (distance < tolerances(0)) {
+              vertex_found = true;
+            };
+          }
+        }
+
+        if (vertex_found)
+          break;
+
+        for (int j = 0; j < 3; ++j) {
+          // Every triangle (face) is connected to 3 edges
+          const int edgeID = tris2edges_adj.ab2b[triangleID * 3 + j];
+
+          auto vertex_a_id = edges2verts_adj.ab2b[edgeID * 2];
+          auto vertex_b_id = edges2verts_adj.ab2b[edgeID * 2 + 1];
+
+          auto vertex_a = Omega_h::get_vector<2>(coords, vertex_a_id);
+          auto vertex_b = Omega_h::get_vector<2>(coords, vertex_b_id);
+
+          if (!normal_intersects_segment(point, vertex_a, vertex_b))
+            continue;
+
+          const auto xa = vertex_a[0];
+          const auto ya = vertex_a[1];
+          const auto xb = vertex_b[0];
+          const auto yb = vertex_b[1];
+
+          const auto xp = point[0];
+          const auto yp = point[1];
+
+          const auto distance_to_ab =
+            distance_from_line(xp, yp, xa, ya, xb, yb);
+
+          if (distance_to_ab < distance_to_nearest) {
+            dimensionality = GridPointSearch2D::Result::Dimensionality::EDGE;
+            nearest_element_id = edgeID;
+            distance_to_nearest = distance_to_ab;
+            parametric_coords_to_nearest = parametric_coords;
+
+            if (distance_to_ab < tolerances(1)) {
+              edge_found = true;
+            };
+          }
+        }
+
+        if (edge_found)
+          break;
+
+        if (Omega_h::is_barycentric_inside(parametric_coords, fuzz)) {
+          dimensionality = GridPointSearch2D::Result::Dimensionality::FACE;
+          nearest_element_id = triangleID;
+          parametric_coords_to_nearest = parametric_coords;
+          inside_cell = true;
+
+          // results(p) =
+          // GridPointSearch2D::Result{GridPointSearch2D::Result::Dimensionality::FACE,
+          // triangleID, parametric_coords}; return;
+        }
       }
 
-      // TODO: Get nearest element if no triangle found
-    }
-    if(!found)
-    {
-      results(p) = GridPointSearch3D::Result{dimensionality, -1 * candidate_map.entries(nearest_triangle), parametric_coords_to_nearest};
-    }
-  });
+      const int inside_mesh =
+        vertex_found || edge_found || inside_cell ? 1 : -1;
+      results(p) = GridPointSearch2D::Result{dimensionality,
+                                             inside_mesh * nearest_element_id,
+                                             parametric_coords_to_nearest};
+    });
+
+  return results;
+}
+
+GridPointSearch2D::GridPointSearch2D(Omega_h::Mesh& mesh, LO Nx, LO Ny)
+  : GridPointSearch2D(mesh, Nx, Ny,
+                      PointSearchTolerances{"point search 2d tolerances"})
+{
+  Kokkos::deep_copy(tolerances_, 0);
+}
+
+GridPointSearch2D::GridPointSearch2D(Omega_h::Mesh& mesh, LO Nx, LO Ny,
+                                     const PointSearchTolerances& tolerances)
+  : PointLocalizationSearch(tolerances)
+{
+  auto mesh_bbox = Omega_h::get_bounding_box<2>(&mesh);
+  auto grid_h = Kokkos::create_mirror_view(grid_);
+  grid_h(0) =
+    Uniform2DGrid{.edge_length = {mesh_bbox.max[0] - mesh_bbox.min[0],
+                                  mesh_bbox.max[1] - mesh_bbox.min[1]},
+                  .bot_left = {mesh_bbox.min[0], mesh_bbox.min[1]},
+                  .divisions = {Nx, Ny}};
+  Kokkos::deep_copy(grid_, grid_h);
+  candidate_map_ =
+    detail::construct_intersection_map_2d(mesh, grid_, grid_h(0).GetNumCells());
+  coords_ = mesh.coords();
+  tris2verts_ = mesh.ask_elem_verts();
+  tris2edges_adj_ = mesh.ask_down(Omega_h::FACE, Omega_h::EDGE);
+  tris2verts_adj_ = mesh.ask_down(Omega_h::FACE, Omega_h::VERT);
+  edges2verts_adj_ = mesh.ask_down(Omega_h::EDGE, Omega_h::VERT);
+}
+
+Kokkos::View<GridPointSearch3D::Result*> GridPointSearch3D::operator()(
+  Kokkos::View<Real* [DIM]> points) const
+{
+  Kokkos::View<GridPointSearch3D::Result*> results("point search result",
+                                                   points.extent(0));
+  auto num_rows = candidate_map_.numRows();
+  // needed so that we don't capture this ptr which will be memory error on cuda
+  auto grid = grid_;
+  auto candidate_map = candidate_map_;
+  auto tris2verts = tris2verts_;
+  auto tris2verts_adj = tris2verts_adj_;
+  auto tris2edges_adj = tris2edges_adj_;
+  auto edges2verts_adj = edges2verts_adj_;
+  auto coords = coords_;
+  Kokkos::parallel_for(
+    points.extent(0), KOKKOS_LAMBDA(int p) {
+      Omega_h::Vector<DIM> point;
+      for (int i = 0; i < DIM; ++i) {
+        point[i] = points(p, i);
+      }
+
+      auto cell_id = grid(0).ClosestCellID(point);
+      assert(cell_id < num_rows && cell_id >= 0);
+      auto candidates_begin = candidate_map.row_map(cell_id);
+      auto candidates_end = candidate_map.row_map(cell_id + 1);
+      bool found = false;
+
+      auto nearest_triangle = candidates_begin;
+      auto dimensionality = GridPointSearch3D::Result::Dimensionality::EDGE;
+      Omega_h::Real distance_to_nearest{INFINITY};
+      Omega_h::Vector<DIM + 1> parametric_coords_to_nearest;
+      // create array that's size of number of candidates x num coords to store
+      // parametric inversion
+      for (auto i = candidates_begin; i < candidates_end; ++i) {
+        const int triangleID = candidate_map.entries(i);
+        const auto elem_tri2verts =
+          Omega_h::gather_verts<DIM + 1>(tris2verts, triangleID);
+        auto vertex_coords =
+          Omega_h::gather_vectors<DIM + 1, DIM>(coords, elem_tri2verts);
+        auto parametric_coords =
+          Omega_h::barycentric_from_global<DIM, DIM>(point, vertex_coords);
+
+        if (Omega_h::is_barycentric_inside(parametric_coords, fuzz)) {
+          results(p) = GridPointSearch3D::Result{
+            GridPointSearch3D::Result::Dimensionality::REGION, triangleID,
+            parametric_coords};
+          found = true;
+          break;
+        }
+
+        // TODO: Get nearest element if no triangle found
+      }
+      if (!found) {
+        results(p) = GridPointSearch3D::Result{
+          dimensionality, -1 * candidate_map.entries(nearest_triangle),
+          parametric_coords_to_nearest};
+      }
+    });
 
   return results;
 }
 
 GridPointSearch3D::GridPointSearch3D(Omega_h::Mesh& mesh, LO Nx, LO Ny, LO Nz)
-  : GridPointSearch3D(mesh, Nx, Ny, Nz,  PointSearchTolerances { "point search 3d tolerances" })
+  : GridPointSearch3D(mesh, Nx, Ny, Nz,
+                      PointSearchTolerances{"point search 3d tolerances"})
 {
   Kokkos::deep_copy(tolerances_, 0);
 }
 
 GridPointSearch3D::GridPointSearch3D(Omega_h::Mesh& mesh, LO Nx, LO Ny, LO Nz,
                                      const PointSearchTolerances& tolerances)
-                                       : PointLocalizationSearch(tolerances)
+  : PointLocalizationSearch(tolerances)
 {
   auto mesh_bbox = Omega_h::get_bounding_box<3>(&mesh);
   auto grid_h = Kokkos::create_mirror_view(grid_);
 
-  std::array<Real, DIM> edge_lengths {};
-  std::array<Real, DIM> bot_left {};
+  std::array<Real, DIM> edge_lengths{};
+  std::array<Real, DIM> bot_left{};
 
   for (int i = 0; i < DIM; ++i) {
     edge_lengths[i] = mesh_bbox.max[i] - mesh_bbox.min[i];
     bot_left[i] = mesh_bbox.min[i];
   }
 
-  grid_h(0) = Uniform3DGrid {
-    .edge_length = edge_lengths,
-    .bot_left = bot_left,
-    .divisions = {Nx, Ny, Nz}
-  };
+  grid_h(0) = Uniform3DGrid{.edge_length = edge_lengths,
+                            .bot_left = bot_left,
+                            .divisions = {Nx, Ny, Nz}};
 
   Kokkos::deep_copy(grid_, grid_h);
-  candidate_map_ = detail::construct_intersection_map_3d(mesh, grid_, grid_h(0).GetNumCells());
+  candidate_map_ =
+    detail::construct_intersection_map_3d(mesh, grid_, grid_h(0).GetNumCells());
   coords_ = mesh.coords();
   tris2verts_ = mesh.ask_elem_verts();
   tris2edges_adj_ = mesh.ask_down(Omega_h::FACE, Omega_h::EDGE);

--- a/src/pcms/point_search.cpp
+++ b/src/pcms/point_search.cpp
@@ -2,35 +2,29 @@
 #include <Omega_h_mesh.hpp>
 #include <bitset>
 
-// From
-// https://en.wikipedia.org/wiki/Distance_from_a_point_to_a_line#Line_defined_by_two_points
+// From https://en.wikipedia.org/wiki/Distance_from_a_point_to_a_line#Line_defined_by_two_points
 KOKKOS_INLINE_FUNCTION
-double distance_from_line(const double x0, const double y0, const double x1,
-                          const double y1, const double x2, const double y2)
+double distance_from_line(const double x0, const double y0, const double x1, const double y1, const double x2, const double y2)
 {
-  const Omega_h::Vector<2> p1 = {x1, y1};
-  const Omega_h::Vector<2> p2 = {x2, y2};
+  const Omega_h::Vector<2> p1 = { x1, y1 };
+  const Omega_h::Vector<2> p2 = { x2, y2 };
   auto disp = p2 - p1;
 
-  return std::abs(disp[1] * x0 - disp[0] * y0 + x2 * y1 - y2 * x1) /
-         Omega_h::norm(disp);
+  return std::abs(disp[1]*x0 - disp[0]*y0 + x2*y1 - y2*x1) / Omega_h::norm(disp);
 }
 
-// Law of Cosines, where a, b, c and gamma are defined here:
-// https://en.wikipedia.org/wiki/Law_of_cosines#Use_in_solving_triangles
+// Law of Cosines, where a, b, c and gamma are defined here: https://en.wikipedia.org/wiki/Law_of_cosines#Use_in_solving_triangles
 KOKKOS_INLINE_FUNCTION
 double angle_from_side_lengths(const double a, const double b, const double c)
 {
-  return std::acos((a * a + b * b - c * c) / 2 * a * b);
+  return std::acos((a*a + b*b - c*c) / 2*a*b);
 }
 
 KOKKOS_INLINE_FUNCTION
-bool normal_intersects_segment(const Omega_h::Few<double, 2> a,
-                               const Omega_h::Few<double, 2> b,
-                               const Omega_h::Few<double, 2> c)
+bool normal_intersects_segment(const Omega_h::Few<double, 2> a, const Omega_h::Few<double, 2> b, const Omega_h::Few<double, 2> c)
 {
   const auto ab_len = Omega_h::norm(a - b);
-  const auto bc_len = Omega_h::norm(b - c);
+  const auto bc_len = Omega_h::norm(b -c);
   const auto ac_len = Omega_h::norm(a - c);
 
   const double angle1 = angle_from_side_lengths(bc_len, ac_len, ab_len);
@@ -117,40 +111,29 @@ bool line_intersects_bbox(const Omega_h::Vector<2>& p0,
   return false;
 }
 
-[[nodiscard]] KOKKOS_INLINE_FUNCTION bool within_bbox(
-  const Omega_h::Vector<2> coord, const AABBox<2>& bbox) noexcept
-{
+[[nodiscard]] KOKKOS_INLINE_FUNCTION
+bool within_bbox(const Omega_h::Vector<2> coord, const AABBox<2> & bbox) noexcept {
   auto left = bbox.center[0] - bbox.half_width[0];
   auto right = bbox.center[0] + bbox.half_width[0];
   auto bot = bbox.center[1] - bbox.half_width[1];
   auto top = bbox.center[1] + bbox.half_width[1];
-  return (coord[0] >= left) && (coord[0] <= right) && (coord[1] >= bot) &&
-         (coord[1] <= top);
+  return (coord[0]>=left) && (coord[0]<=right) && (coord[1] >= bot) && (coord[1]<=top);
 }
 
-[[nodiscard]] KOKKOS_INLINE_FUNCTION bool bbox_verts_within_triangle(
-  const AABBox<2>& bbox, const Omega_h::Matrix<2, 3>& coords)
-{
+[[nodiscard]] KOKKOS_INLINE_FUNCTION
+bool bbox_verts_within_triangle(const AABBox<2>& bbox, const Omega_h::Matrix<2,3>& coords) {
   auto left = bbox.center[0] - bbox.half_width[0];
   auto right = bbox.center[0] + bbox.half_width[0];
   auto bot = bbox.center[1] - bbox.half_width[1];
   auto top = bbox.center[1] + bbox.half_width[1];
-  auto xi = barycentric_from_global({left, bot}, coords);
-  if (Omega_h::is_barycentric_inside(xi, fuzz)) {
-    return true;
-  }
-  xi = barycentric_from_global({left, top}, coords);
-  if (Omega_h::is_barycentric_inside(xi, fuzz)) {
-    return true;
-  }
-  xi = barycentric_from_global({right, top}, coords);
-  if (Omega_h::is_barycentric_inside(xi, fuzz)) {
-    return true;
-  }
-  xi = barycentric_from_global({right, bot}, coords);
-  if (Omega_h::is_barycentric_inside(xi, fuzz)) {
-    return true;
-  }
+  auto xi = barycentric_from_global({left,bot}, coords);
+  if(Omega_h::is_barycentric_inside(xi, fuzz)){ return true;}
+  xi = barycentric_from_global({left,top}, coords);
+  if(Omega_h::is_barycentric_inside(xi, fuzz)){ return true;}
+  xi = barycentric_from_global({right,top}, coords);
+  if(Omega_h::is_barycentric_inside(xi, fuzz)){ return true;}
+  xi = barycentric_from_global({right,bot}, coords);
+  if(Omega_h::is_barycentric_inside(xi, fuzz)){ return true;}
   return false;
 }
 
@@ -159,13 +142,15 @@ bool line_intersects_bbox(const Omega_h::Vector<2>& p0,
  * intersects with a bounding box
  */
 [[nodiscard]]
-KOKKOS_FUNCTION bool triangle_intersects_bbox(
-  const Omega_h::Matrix<2, 3>& coords, const AABBox<2>& bbox)
+KOKKOS_FUNCTION
+bool triangle_intersects_bbox(const Omega_h::Matrix<2, 3>& coords,
+                                            const AABBox<2>& bbox)
 {
   // triangle and grid cell bounding box intersect
   if (intersects(triangle_bbox(coords), bbox)) {
     // if any of the triangle verts inside of bbox
-    if (within_bbox(coords[0], bbox) || within_bbox(coords[1], bbox) ||
+    if (within_bbox(coords[0], bbox) ||
+        within_bbox(coords[1], bbox) ||
         within_bbox(coords[2], bbox)) {
       return true;
     }
@@ -197,8 +182,7 @@ namespace detail
  */
 struct GridTriIntersectionFunctor
 {
-  GridTriIntersectionFunctor(Omega_h::Mesh& mesh,
-                             Kokkos::View<Uniform2DGrid[1]> grid)
+  GridTriIntersectionFunctor(Omega_h::Mesh& mesh, Kokkos::View<Uniform2DGrid[1]> grid)
     : mesh_(mesh),
       tris2verts_(mesh_.ask_elem_verts()),
       coords_(mesh_.coords()),
@@ -221,11 +205,9 @@ struct GridTriIntersectionFunctor
     LO num_intersections = 0;
     // hierarchical parallel may make be very beneficial here...
     for (LO elem_idx = 0; elem_idx < nelems_; ++elem_idx) {
-      const auto elem_tri2verts =
-        Omega_h::gather_verts<3>(tris2verts_, elem_idx);
+      const auto elem_tri2verts = Omega_h::gather_verts<3>(tris2verts_, elem_idx);
       // 2d mesh with 2d coords, but 3 triangles
-      const auto vertex_coords =
-        Omega_h::gather_vectors<3, 2>(coords_, elem_tri2verts);
+      const auto vertex_coords = Omega_h::gather_vectors<3, 2>(coords_, elem_tri2verts);
       if (triangle_intersects_bbox(vertex_coords, grid_cell_bbox)) {
         if (fill) {
           fill[num_intersections] = elem_idx;
@@ -241,17 +223,14 @@ private:
   Omega_h::LOs tris2verts_;
   Omega_h::Reals coords_;
   Kokkos::View<Uniform2DGrid[1]> grid_;
-
 public:
   LO nelems_;
 };
 
-// num_grid_cells should be result of grid.GetNumCells(), take as argument to
-// avoid extra copy of grid from gpu to cpu
+// num_grid_cells should be result of grid.GetNumCells(), take as argument to avoid extra copy
+// of grid from gpu to cpu
 Kokkos::Crs<LO, Kokkos::DefaultExecutionSpace, void, LO>
-construct_intersection_map(Omega_h::Mesh& mesh,
-                           Kokkos::View<Uniform2DGrid[1]> grid,
-                           int num_grid_cells)
+construct_intersection_map(Omega_h::Mesh& mesh, Kokkos::View<Uniform2DGrid[1]> grid, int num_grid_cells)
 {
   Kokkos::Crs<LO, Kokkos::DefaultExecutionSpace, void, LO> intersection_map{};
   auto f = detail::GridTriIntersectionFunctor{mesh, grid};
@@ -272,137 +251,117 @@ Omega_h::Vector<3> barycentric_from_global(
   return {1 - xi[0] - xi[1], xi[0], xi[1]};
 }
 
-template <int n, typename Op>
-OMEGA_H_INLINE double myreduce(const Omega_h::Vector<n>& x,
-                               Op op) OMEGA_H_NOEXCEPT
-{
+template <int n,  typename Op>
+OMEGA_H_INLINE double myreduce(const Omega_h::Vector<n> & x, Op op) OMEGA_H_NOEXCEPT {
   auto out = x[0];
-  for (int i = 1; i < n; ++i)
-    out = op(out, x[i]);
+  for (int i = 1; i < n; ++i) out = op(out, x[i]);
   return out;
-}
+}         
 
-Kokkos::View<GridPointSearch::Result*> GridPointSearch::operator()(
-  Kokkos::View<Real* [dim]> points) const
+Kokkos::View<GridPointSearch2D::Result*> GridPointSearch2D::operator()(Kokkos::View<Real*[DIM] > points) const
 {
-  static_assert(dim == 2, "point search assumes dim==2");
-  Kokkos::View<GridPointSearch::Result*> results("point search result",
-                                                 points.extent(0));
+  Kokkos::View<GridPointSearch::Result*> results("point search result", points.extent(0));
   auto num_rows = candidate_map_.numRows();
   // needed so that we don't capture this ptr which will be memory error on cuda
-  auto grid = grid_;
+  auto grid = grid_; 
   auto candidate_map = candidate_map_;
   auto tris2verts = tris2verts_;
   auto tris2verts_adj = tris2verts_adj_;
   auto tris2edges_adj = tris2edges_adj_;
   auto edges2verts_adj = edges2verts_adj_;
   auto coords = coords_;
-  Kokkos::parallel_for(
-    points.extent(0), KOKKOS_LAMBDA(int p) {
-      Omega_h::Vector<2> point(
-        std::initializer_list<double>{points(p, 0), points(p, 1)});
-      auto cell_id = grid(0).ClosestCellID(point);
-      assert(cell_id < num_rows && cell_id >= 0);
-      auto candidates_begin = candidate_map.row_map(cell_id);
-      auto candidates_end = candidate_map.row_map(cell_id + 1);
-      bool found = false;
+  Kokkos::parallel_for(points.extent(0), KOKKOS_LAMBDA(int p) {
+    Omega_h::Vector<2> point(std::initializer_list<double>{points(p,0), points(p,1)});
+    auto cell_id = grid(0).ClosestCellID(point);
+    assert(cell_id < num_rows && cell_id >= 0);
+    auto candidates_begin = candidate_map.row_map(cell_id);
+    auto candidates_end = candidate_map.row_map(cell_id + 1);
+    bool found = false;
 
-      auto nearest_triangle = candidates_begin;
-      auto dimensionality = GridPointSearch::Result::Dimensionality::EDGE;
-      Omega_h::Real distance_to_nearest{INFINITY};
-      Omega_h::Vector<3> parametric_coords_to_nearest;
-      // create array that's size of number of candidates x num coords to store
-      // parametric inversion
-      for (auto i = candidates_begin; i < candidates_end; ++i) {
-        const int triangleID = candidate_map.entries(i);
-        const auto elem_tri2verts =
-          Omega_h::gather_verts<3>(tris2verts, triangleID);
-        // 2d mesh with 2d coords, but 3 triangles
-        auto vertex_coords =
-          Omega_h::gather_vectors<3, 2>(coords, elem_tri2verts);
-        auto parametric_coords = barycentric_from_global(point, vertex_coords);
+    auto nearest_triangle = candidates_begin;
+    auto dimensionality = GridPointSearch::Result::Dimensionality::EDGE;
+    Omega_h::Real distance_to_nearest { INFINITY };
+    Omega_h::Vector<3> parametric_coords_to_nearest;
+    // create array that's size of number of candidates x num coords to store
+    // parametric inversion
+    for (auto i = candidates_begin; i < candidates_end; ++i) {
+      const int triangleID = candidate_map.entries(i);
+      const auto elem_tri2verts = Omega_h::gather_verts<3>(tris2verts, triangleID);
+      // 2d mesh with 2d coords, but 3 triangles
+      auto vertex_coords = Omega_h::gather_vectors<3, 2>(coords, elem_tri2verts);
+      auto parametric_coords = barycentric_from_global(point, vertex_coords);
 
-        if (Omega_h::is_barycentric_inside(parametric_coords, fuzz)) {
-          results(p) = GridPointSearch::Result{
-            GridPointSearch::Result::Dimensionality::FACE, triangleID,
-            parametric_coords};
-          found = true;
-          break;
-        }
-
-        for (int j = 0; j < 3; ++j) {
-          // Every triangle (face) is connected to 3 edges
-          const int edgeID = tris2edges_adj.ab2b[triangleID * 3 + j];
-
-          auto vertex_a_id = edges2verts_adj.ab2b[edgeID * 2];
-          auto vertex_b_id = edges2verts_adj.ab2b[edgeID * 2 + 1];
-
-          auto vertex_a = Omega_h::get_vector<2>(coords, vertex_a_id);
-          auto vertex_b = Omega_h::get_vector<2>(coords, vertex_b_id);
-
-          if (!normal_intersects_segment(point, vertex_a, vertex_b))
-            continue;
-
-          const auto xa = vertex_a[0];
-          const auto ya = vertex_a[1];
-          const auto xb = vertex_b[0];
-          const auto yb = vertex_b[1];
-
-          const auto xp = point[0];
-          const auto yp = point[1];
-
-          const auto distance_to_ab =
-            distance_from_line(xp, yp, xa, ya, xb, yb);
-
-          if (distance_to_ab >= distance_to_nearest) {
-            continue;
-          }
-
-          dimensionality = GridPointSearch::Result::Dimensionality::EDGE;
-          nearest_triangle = i;
-          distance_to_nearest = distance_to_ab;
-          parametric_coords_to_nearest = parametric_coords;
-        }
-
-        // Every triangle (face) is connected to 3 vertices
-        for (int j = 0; j < 3; ++j) {
-          // Get the vertex ID from the connectivity array
-          const int vertexID = tris2verts_adj.ab2b[triangleID * 3 + j];
-          // Get the vertex coordinates from the mesh using vertexID
-          const Omega_h::Few<double, 2> vertex =
-            Omega_h::get_vector<2>(coords, vertexID);
-
-          if (const auto distance = Omega_h::norm(point - vertex);
-              distance < distance_to_nearest) {
-            dimensionality = GridPointSearch::Result::Dimensionality::VERTEX;
-            nearest_triangle = i;
-            distance_to_nearest = distance;
-            parametric_coords_to_nearest = parametric_coords;
-          }
-        }
+      if (Omega_h::is_barycentric_inside(parametric_coords, fuzz)) {
+        results(p) = GridPointSearch::Result{GridPointSearch::Result::Dimensionality::FACE, triangleID, parametric_coords};
+        found = true;
+        break;
       }
-      if (!found) {
-        results(p) = GridPointSearch::Result{
-          dimensionality, -1 * candidate_map.entries(nearest_triangle),
-          parametric_coords_to_nearest};
+
+     for (int j = 0; j < 3; ++j) {
+       // Every triangle (face) is connected to 3 edges
+       const int edgeID = tris2edges_adj.ab2b[triangleID * 3 + j];
+
+       auto vertex_a_id = edges2verts_adj.ab2b[edgeID * 2];
+       auto vertex_b_id = edges2verts_adj.ab2b[edgeID * 2 + 1];
+
+       auto vertex_a = Omega_h::get_vector<2>(coords, vertex_a_id);
+       auto vertex_b = Omega_h::get_vector<2>(coords, vertex_b_id);
+
+       if (!normal_intersects_segment(point, vertex_a, vertex_b)) continue;
+
+       const auto xa = vertex_a[0];
+       const auto ya = vertex_a[1];
+       const auto xb = vertex_b[0];
+       const auto yb = vertex_b[1];
+
+       const auto xp = point[0];
+       const auto yp = point[1];
+
+       const auto distance_to_ab = distance_from_line(xp, yp, xa, ya, xb, yb);
+
+       if (distance_to_ab >= distance_to_nearest) { continue; }
+
+       dimensionality = GridPointSearch::Result::Dimensionality::EDGE;
+       nearest_triangle = i;
+       distance_to_nearest = distance_to_ab;
+       parametric_coords_to_nearest = parametric_coords;
       }
-    });
+
+      // Every triangle (face) is connected to 3 vertices
+      for (int j = 0; j < 3; ++j) {
+        // Get the vertex ID from the connectivity array
+        const int vertexID = tris2verts_adj.ab2b[triangleID * 3 + j];
+        // Get the vertex coordinates from the mesh using vertexID
+        const Omega_h::Few<double, 2> vertex =
+          Omega_h::get_vector<2>(coords, vertexID);
+
+        if (const auto distance = Omega_h::norm(point - vertex);distance < distance_to_nearest) {
+         dimensionality = GridPointSearch::Result::Dimensionality::VERTEX;
+         nearest_triangle = i;
+         distance_to_nearest = distance;
+         parametric_coords_to_nearest = parametric_coords;
+       }
+      }
+    }
+    if(!found)
+    {
+      results(p) = GridPointSearch::Result{dimensionality, -1 * candidate_map.entries(nearest_triangle), parametric_coords_to_nearest};
+    }
+  });
 
   return results;
 }
 
-GridPointSearch::GridPointSearch(Omega_h::Mesh& mesh, LO Nx, LO Ny)
+GridPointSearch<2>::GridPointSearch(Omega_h::Mesh& mesh, LO Nx, LO Ny)
 {
   auto mesh_bbox = Omega_h::get_bounding_box<2>(&mesh);
   auto grid_h = Kokkos::create_mirror_view(grid_);
-  grid_h(0) =
-    Uniform2DGrid{.edge_length = {mesh_bbox.max[0] - mesh_bbox.min[0],
-                                  mesh_bbox.max[1] - mesh_bbox.min[1]},
-                  .bot_left = {mesh_bbox.min[0], mesh_bbox.min[1]},
-                  .divisions = {Nx, Ny}};
+  grid_h(0) = Uniform2DGrid{.edge_length = {mesh_bbox.max[0] - mesh_bbox.min[0],
+                           mesh_bbox.max[1] - mesh_bbox.min[1]},
+    .bot_left = {mesh_bbox.min[0], mesh_bbox.min[1]},
+    .divisions = {Nx, Ny}};
   Kokkos::deep_copy(grid_, grid_h);
-  candidate_map_ =
-    detail::construct_intersection_map(mesh, grid_, grid_h(0).GetNumCells());
+  candidate_map_ = detail::construct_intersection_map(mesh, grid_, grid_h(0).GetNumCells());
   coords_ = mesh.coords();
   tris2verts_ = mesh.ask_elem_verts();
   tris2edges_adj_ = mesh.ask_down(Omega_h::FACE, Omega_h::EDGE);

--- a/src/pcms/point_search.cpp
+++ b/src/pcms/point_search.cpp
@@ -331,7 +331,7 @@ struct GridTriIntersectionFunctor3D
   {
     if (mesh_.dim() != 3) {
       std::cerr << "GridTriIntersection3D currently only developed for 3D "
-                   "triangular meshes\n";
+                   "tetrahedral meshes\n";
       std::terminate();
     }
   }

--- a/src/pcms/point_search.cpp
+++ b/src/pcms/point_search.cpp
@@ -456,7 +456,6 @@ Kokkos::View<GridPointSearch2D::Result*> GridPointSearch2D::operator()(Kokkos::V
         const auto distance_to_ab = distance_from_line(xp, yp, xa, ya, xb, yb);
 
         if (distance_to_ab < distance_to_nearest) {
-          edge_found = true;
           dimensionality = GridPointSearch2D::Result::Dimensionality::EDGE;
           nearest_element_id = edgeID;
           distance_to_nearest = distance_to_ab;

--- a/src/pcms/point_search.cpp
+++ b/src/pcms/point_search.cpp
@@ -61,9 +61,12 @@ AABBox<2> triangle_bbox(const Omega_h::Matrix<2, 3>& coords)
 template <unsigned dim>
 AABBox<dim> simplex_bbox(const Omega_h::Matrix<dim, dim + 1>& coords)
 {
-  std::array<Real, dim> max{coords(0, 0), coords(1, 0)};
-  std::array<Real, dim> min{coords(0, 0), coords(1, 0)};
-
+  std::array<Real, dim> max;
+  std::array<Real, dim> min;
+  for (int j = 0; j < dim; ++j) {
+    max[j] = coords(j, 0);
+    min[j] = coords(j, 0);
+  }
   for (int i = 1; i < dim + 1; ++i) {
     for (int j = 0; j < dim; ++j) {
       max[j] = std::fmax(max[j], coords(j, i));

--- a/src/pcms/point_search.cpp
+++ b/src/pcms/point_search.cpp
@@ -177,9 +177,11 @@ bool bbox_verts_within_simplex(const AABBox<dim>& bbox, const Omega_h::Matrix<di
   }
 
   // 1 << dim == 2 ** dim == num vertices in ndim bounding box / hypercube
+  constexpr unsigned num_verts = 1 << dim;
+
   // Each vertex is a just a unique combination of walls
   // eg [left, bottom] (2D) or [right, top, front] (3)
-  for (unsigned i = 0; i < 1 << dim; ++i) {
+  for (unsigned i = 0; i < num_verts; ++i) {
     // conveniently, i acts a bit field representing the current combination
     Omega_h::Vector<dim> vert;
     for (unsigned j = 0; j < dim; ++j) {
@@ -517,7 +519,7 @@ Kokkos::View<GridPointSearch3D::Result*> GridPointSearch3D::operator()(Kokkos::V
       auto parametric_coords = Omega_h::barycentric_from_global<DIM, DIM>(point, vertex_coords);
 
       if (Omega_h::is_barycentric_inside(parametric_coords, fuzz)) {
-        results(p) = GridPointSearch3D::Result{GridPointSearch3D::Result::Dimensionality::FACE, triangleID, parametric_coords};
+        results(p) = GridPointSearch3D::Result{GridPointSearch3D::Result::Dimensionality::REGION, triangleID, parametric_coords};
         found = true;
         break;
       }

--- a/src/pcms/point_search.h
+++ b/src/pcms/point_search.h
@@ -44,6 +44,7 @@ public:
   static constexpr auto DIM = dim;
 
   virtual Kokkos::View<Result*> operator()(Kokkos::View<Real*[dim] > point) const = 0;
+  virtual ~PointLocalizationSearch() = default;
 };
 
 using PointLocalizationSearch2D = PointLocalizationSearch<2>;

--- a/src/pcms/point_search.h
+++ b/src/pcms/point_search.h
@@ -115,11 +115,11 @@ public:
                     const PointSearchTolerances& tolerances);
 
   /**
-   *  given a point in global coordinates give the id of the triangle that the
-   * point lies within and the parametric coordinate of the point within the
-   * triangle. If the point does not lie within any triangle element. Then the
+   *  Given a point in global coordinates, returns the id of the tetrahedron (3D element)
+   * that the point lies within and the parametric coordinate of the point within the
+   * tetrahedron. If the point does not lie within any tetrahedron element, then the
    * id will be a negative number and (TODO) will return a negative id of the
-   * closest element
+   * closest element.
    */
   Kokkos::View<Result*> operator()(
     Kokkos::View<Real* [DIM]> point) const override;

--- a/src/pcms/point_search.h
+++ b/src/pcms/point_search.h
@@ -33,7 +33,8 @@ public:
     {
       VERTEX = 0,
       EDGE = 1,
-      FACE = 2
+      FACE = 2,
+      REGION = 3
     };
 
     Dimensionality dimensionality;

--- a/src/pcms/point_search.h
+++ b/src/pcms/point_search.h
@@ -44,8 +44,15 @@ public:
 
   static constexpr auto DIM = dim;
 
+  using PointSearchTolerances = Kokkos::View<Real[DIM]>;
+
+  explicit PointLocalizationSearch(PointSearchTolerances tolerances) : tolerances_(tolerances){ }
+
   virtual Kokkos::View<Result*> operator()(Kokkos::View<Real*[dim] > point) const = 0;
   virtual ~PointLocalizationSearch() = default;
+
+protected:
+  PointSearchTolerances tolerances_;
 };
 
 using PointLocalizationSearch2D = PointLocalizationSearch<2>;
@@ -59,6 +66,8 @@ public:
   using Result = PointLocalizationSearch2D::Result;
 
   GridPointSearch2D(Omega_h::Mesh& mesh, LO Nx, LO Ny);
+  GridPointSearch2D(Omega_h::Mesh& mesh, LO Nx, LO Ny, PointSearchTolerances tolerances);
+
   /**
    *  given a point in global coordinates give the id of the triangle that the
    * point lies within and the parametric coordinate of the point within the

--- a/src/pcms/point_search.h
+++ b/src/pcms/point_search.h
@@ -17,7 +17,7 @@ namespace pcms
 // used
 namespace detail {
 Kokkos::Crs<LO, Kokkos::DefaultExecutionSpace, void, LO>
-construct_intersection_map(Omega_h::Mesh& mesh, Kokkos::View<Uniform2DGrid[1]> grid, int num_grid_cells);
+construct_intersection_map_2d(Omega_h::Mesh& mesh, Kokkos::View<Uniform2DGrid[1]> grid, int num_grid_cells);
 }
 KOKKOS_FUNCTION
 
@@ -48,6 +48,7 @@ public:
 };
 
 using PointLocalizationSearch2D = PointLocalizationSearch<2>;
+using PointLocalizationSearch3D = PointLocalizationSearch<3>;
 
 class GridPointSearch2D : public PointLocalizationSearch2D
 {
@@ -72,6 +73,34 @@ private:
   Omega_h::Adj tris2verts_adj_;
   Omega_h::Adj edges2verts_adj_;
   Kokkos::View<Uniform2DGrid[1]> grid_{"uniform grid"};
+  CandidateMapT candidate_map_;
+  Omega_h::LOs tris2verts_;
+  Omega_h::Reals coords_;
+};
+
+class GridPointSearch3D : public PointLocalizationSearch3D
+{
+  using CandidateMapT = Kokkos::Crs<LO, Kokkos::DefaultExecutionSpace, void, LO>;
+
+public:
+  using Result = PointLocalizationSearch3D::Result;
+
+  GridPointSearch3D(Omega_h::Mesh& mesh, LO Nx, LO Ny, LO Nz);
+  /**
+   *  given a point in global coordinates give the id of the triangle that the
+   * point lies within and the parametric coordinate of the point within the
+   * triangle. If the point does not lie within any triangle element. Then the
+   * id will be a negative number and (TODO) will return a negative id of the
+   * closest element
+   */
+  Kokkos::View<Result*> operator()(Kokkos::View<Real* [DIM]> point) const override;
+
+private:
+  Omega_h::Mesh mesh_;
+  Omega_h::Adj tris2edges_adj_;
+  Omega_h::Adj tris2verts_adj_;
+  Omega_h::Adj edges2verts_adj_;
+  Kokkos::View<UniformGrid<DIM>[1]> grid_{"uniform grid"};
   CandidateMapT candidate_map_;
   Omega_h::LOs tris2verts_;
   Omega_h::Reals coords_;

--- a/src/pcms/point_search.h
+++ b/src/pcms/point_search.h
@@ -20,8 +20,6 @@ Kokkos::Crs<LO, Kokkos::DefaultExecutionSpace, void, LO>
 construct_intersection_map(Omega_h::Mesh& mesh, Kokkos::View<Uniform2DGrid[1]> grid, int num_grid_cells);
 }
 KOKKOS_FUNCTION
-Omega_h::Vector<3> barycentric_from_global(
-  const Omega_h::Vector<2>& point, const Omega_h::Matrix<2, 3>& vertex_coords);
 
 [[nodiscard]] KOKKOS_FUNCTION bool triangle_intersects_bbox(
   const Omega_h::Matrix<2, 3>& coords, const AABBox<2>& bbox);

--- a/src/pcms/point_search.h
+++ b/src/pcms/point_search.h
@@ -48,6 +48,8 @@ public:
   virtual Kokkos::View<Result*> operator()(Kokkos::View<Real*[dim] > point) const = 0;
 };
 
+using PointLocalizationSearch2D = PointLocalizationSearch<2>;
+
 template <int dim>
 class GridPointSearch : public PointLocalizationSearch<dim>
 {
@@ -55,12 +57,12 @@ class GridPointSearch : public PointLocalizationSearch<dim>
 };
 
 template <>
-class GridPointSearch<2> : public PointLocalizationSearch<2>
+class GridPointSearch<2> : public PointLocalizationSearch2D
 {
   using CandidateMapT = Kokkos::Crs<LO, Kokkos::DefaultExecutionSpace, void, LO>;
 
 public:
-  using Result = PointLocalizationSearch::Result;
+  using Result = PointLocalizationSearch2D::Result;
 
   GridPointSearch(Omega_h::Mesh& mesh, LO Nx, LO Ny);
   /**

--- a/src/pcms/point_search.h
+++ b/src/pcms/point_search.h
@@ -43,28 +43,21 @@ public:
     Omega_h::Vector<dim + 1> parametric_coords;
   };
 
-  static constexpr auto DIM = 2;
+  static constexpr auto DIM = dim;
 
   virtual Kokkos::View<Result*> operator()(Kokkos::View<Real*[dim] > point) const = 0;
 };
 
 using PointLocalizationSearch2D = PointLocalizationSearch<2>;
 
-template <int dim>
-class GridPointSearch : public PointLocalizationSearch<dim>
-{
-  static_assert(false, "Not implemented");
-};
-
-template <>
-class GridPointSearch<2> : public PointLocalizationSearch2D
+class GridPointSearch2D : public PointLocalizationSearch2D
 {
   using CandidateMapT = Kokkos::Crs<LO, Kokkos::DefaultExecutionSpace, void, LO>;
 
 public:
   using Result = PointLocalizationSearch2D::Result;
 
-  GridPointSearch(Omega_h::Mesh& mesh, LO Nx, LO Ny);
+  GridPointSearch2D(Omega_h::Mesh& mesh, LO Nx, LO Ny);
   /**
    *  given a point in global coordinates give the id of the triangle that the
    * point lies within and the parametric coordinate of the point within the
@@ -84,8 +77,6 @@ private:
   Omega_h::LOs tris2verts_;
   Omega_h::Reals coords_;
 };
-
-using GridPointSearch2D = GridPointSearch<2>;
 
 } // namespace detail
 #endif // PCMS_COUPLING_POINT_SEARCH_H

--- a/src/pcms/point_search.h
+++ b/src/pcms/point_search.h
@@ -1,11 +1,13 @@
 #ifndef PCMS_COUPLING_POINT_SEARCH_H
 #define PCMS_COUPLING_POINT_SEARCH_H
-#include <unordered_map>
+#include <cassert>
+
 #include <Kokkos_Core.hpp>
 #include <Omega_h_mesh.hpp>
-#include "types.h"
 #include <Omega_h_bbox.hpp>
 #include <Omega_h_shape.hpp>
+
+#include "types.h"
 #include "pcms/uniform_grid.h"
 #include "pcms/bounding_box.h"
 
@@ -38,7 +40,7 @@ public:
     };
 
     Dimensionality dimensionality;
-    LO tri_id;
+    LO element_id;
     Omega_h::Vector<dim + 1> parametric_coords;
   };
 
@@ -46,7 +48,10 @@ public:
 
   using PointSearchTolerances = Kokkos::View<Real[DIM]>;
 
-  explicit PointLocalizationSearch(PointSearchTolerances tolerances) : tolerances_(tolerances){ }
+  explicit PointLocalizationSearch(const PointSearchTolerances& tolerances) : tolerances_(tolerances)
+  {
+    assert(tolerances_.is_allocated());
+  }
 
   virtual Kokkos::View<Result*> operator()(Kokkos::View<Real*[dim] > point) const = 0;
   virtual ~PointLocalizationSearch() = default;
@@ -66,7 +71,7 @@ public:
   using Result = PointLocalizationSearch2D::Result;
 
   GridPointSearch2D(Omega_h::Mesh& mesh, LO Nx, LO Ny);
-  GridPointSearch2D(Omega_h::Mesh& mesh, LO Nx, LO Ny, PointSearchTolerances tolerances);
+  GridPointSearch2D(Omega_h::Mesh& mesh, LO Nx, LO Ny, const PointSearchTolerances& tolerances);
 
   /**
    *  given a point in global coordinates give the id of the triangle that the
@@ -96,6 +101,8 @@ public:
   using Result = PointLocalizationSearch3D::Result;
 
   GridPointSearch3D(Omega_h::Mesh& mesh, LO Nx, LO Ny, LO Nz);
+  GridPointSearch3D(Omega_h::Mesh& mesh, LO Nx, LO Ny, LO Nz, const PointSearchTolerances& tolerances);
+
   /**
    *  given a point in global coordinates give the id of the triangle that the
    * point lies within and the parametric coordinate of the point within the

--- a/src/pcms/point_search.h
+++ b/src/pcms/point_search.h
@@ -17,9 +17,12 @@ namespace pcms
 // TODO take a bounding box as we may want a bbox that's bigger than the mesh!
 // this function is in the public header for testing, but should not be directly
 // used
-namespace detail {
+namespace detail
+{
 Kokkos::Crs<LO, Kokkos::DefaultExecutionSpace, void, LO>
-construct_intersection_map_2d(Omega_h::Mesh& mesh, Kokkos::View<Uniform2DGrid[1]> grid, int num_grid_cells);
+construct_intersection_map_2d(Omega_h::Mesh& mesh,
+                              Kokkos::View<Uniform2DGrid[1]> grid,
+                              int num_grid_cells);
 }
 KOKKOS_FUNCTION
 
@@ -30,7 +33,8 @@ template <int dim>
 class PointLocalizationSearch
 {
 public:
-  struct Result {
+  struct Result
+  {
     enum class Dimensionality
     {
       VERTEX = 0,
@@ -48,12 +52,14 @@ public:
 
   using PointSearchTolerances = Kokkos::View<Real[DIM]>;
 
-  explicit PointLocalizationSearch(const PointSearchTolerances& tolerances) : tolerances_(tolerances)
+  explicit PointLocalizationSearch(const PointSearchTolerances& tolerances)
+    : tolerances_(tolerances)
   {
     assert(tolerances_.is_allocated());
   }
 
-  virtual Kokkos::View<Result*> operator()(Kokkos::View<Real*[dim] > point) const = 0;
+  virtual Kokkos::View<Result*> operator()(
+    Kokkos::View<Real* [dim]> point) const = 0;
   virtual ~PointLocalizationSearch() = default;
 
 protected:
@@ -65,13 +71,15 @@ using PointLocalizationSearch3D = PointLocalizationSearch<3>;
 
 class GridPointSearch2D : public PointLocalizationSearch2D
 {
-  using CandidateMapT = Kokkos::Crs<LO, Kokkos::DefaultExecutionSpace, void, LO>;
+  using CandidateMapT =
+    Kokkos::Crs<LO, Kokkos::DefaultExecutionSpace, void, LO>;
 
 public:
   using Result = PointLocalizationSearch2D::Result;
 
   GridPointSearch2D(Omega_h::Mesh& mesh, LO Nx, LO Ny);
-  GridPointSearch2D(Omega_h::Mesh& mesh, LO Nx, LO Ny, const PointSearchTolerances& tolerances);
+  GridPointSearch2D(Omega_h::Mesh& mesh, LO Nx, LO Ny,
+                    const PointSearchTolerances& tolerances);
 
   /**
    *  given a point in global coordinates give the id of the triangle that the
@@ -80,7 +88,8 @@ public:
    * id will be a negative number and (TODO) will return a negative id of the
    * closest element
    */
-  Kokkos::View<Result*> operator()(Kokkos::View<Real* [DIM]> point) const override;
+  Kokkos::View<Result*> operator()(
+    Kokkos::View<Real* [DIM]> point) const override;
 
 private:
   Omega_h::Mesh mesh_;
@@ -95,13 +104,15 @@ private:
 
 class GridPointSearch3D : public PointLocalizationSearch3D
 {
-  using CandidateMapT = Kokkos::Crs<LO, Kokkos::DefaultExecutionSpace, void, LO>;
+  using CandidateMapT =
+    Kokkos::Crs<LO, Kokkos::DefaultExecutionSpace, void, LO>;
 
 public:
   using Result = PointLocalizationSearch3D::Result;
 
   GridPointSearch3D(Omega_h::Mesh& mesh, LO Nx, LO Ny, LO Nz);
-  GridPointSearch3D(Omega_h::Mesh& mesh, LO Nx, LO Ny, LO Nz, const PointSearchTolerances& tolerances);
+  GridPointSearch3D(Omega_h::Mesh& mesh, LO Nx, LO Ny, LO Nz,
+                    const PointSearchTolerances& tolerances);
 
   /**
    *  given a point in global coordinates give the id of the triangle that the
@@ -110,7 +121,8 @@ public:
    * id will be a negative number and (TODO) will return a negative id of the
    * closest element
    */
-  Kokkos::View<Result*> operator()(Kokkos::View<Real* [DIM]> point) const override;
+  Kokkos::View<Result*> operator()(
+    Kokkos::View<Real* [DIM]> point) const override;
 
 private:
   Omega_h::Mesh mesh_;
@@ -123,5 +135,5 @@ private:
   Omega_h::Reals coords_;
 };
 
-} // namespace detail
+} // namespace pcms
 #endif // PCMS_COUPLING_POINT_SEARCH_H

--- a/src/pcms/uniform_grid.h
+++ b/src/pcms/uniform_grid.h
@@ -6,7 +6,7 @@
 namespace pcms
 {
 
-template <unsigned dim = 2>
+template <unsigned dim>
 struct UniformGrid
 {
   // Make private?
@@ -117,7 +117,8 @@ private:
   }
 };
 
-using Uniform2DGrid = UniformGrid<>;
+using Uniform2DGrid = UniformGrid<2>;
+using Uniform3DGrid = UniformGrid<3>;
 
 } // namespace pcms
 

--- a/test/test_point_search.cpp
+++ b/test/test_point_search.cpp
@@ -111,7 +111,8 @@ bool num_candidates_within_range(const T& intersection_map, pcms::LO min,
   Kokkos::parallel_reduce(
     intersection_map.numRows(),
     KOKKOS_LAMBDA(const int i, result_type& update) {
-      auto num_candidates = intersection_map.row_map(i + 1) - intersection_map.row_map(i);
+      auto num_candidates =
+        intersection_map.row_map(i + 1) - intersection_map.row_map(i);
       if (num_candidates > update.max_val)
         update.max_val = num_candidates;
       if (num_candidates < update.min_val)
@@ -123,11 +124,11 @@ bool num_candidates_within_range(const T& intersection_map, pcms::LO min,
     std::cerr << result.min_val << ' ' << result.max_val << '\n';
   return within_range;
 }
-//extern Omega_h::Library omega_h_library;
+// extern Omega_h::Library omega_h_library;
 
 TEST_CASE("construct intersection map")
 {
-  //auto world = omega_h_library.world();
+  // auto world = omega_h_library.world();
   auto lib = Omega_h::Library{};
   auto world = lib.world();
   auto mesh =
@@ -137,9 +138,11 @@ TEST_CASE("construct intersection map")
   {
     Kokkos::View<Uniform2DGrid[1]> grid_d("uniform grid");
     auto grid_h = Kokkos::create_mirror_view(grid_d);
-    grid_h(0) = Uniform2DGrid{.edge_length{1, 1}, .bot_left = {0, 0}, .divisions = {10, 10}};
+    grid_h(0) = Uniform2DGrid{
+      .edge_length{1, 1}, .bot_left = {0, 0}, .divisions = {10, 10}};
     Kokkos::deep_copy(grid_d, grid_h);
-    auto intersection_map = pcms::detail::construct_intersection_map_2d(mesh, grid_d, grid_h(0).GetNumCells());
+    auto intersection_map = pcms::detail::construct_intersection_map_2d(
+      mesh, grid_d, grid_h(0).GetNumCells());
     // assert(cudaSuccess == cudaDeviceSynchronize());
     REQUIRE(intersection_map.numRows() == 100);
     REQUIRE(num_candidates_within_range(intersection_map, 2, 16));
@@ -148,40 +151,44 @@ TEST_CASE("construct intersection map")
   {
     Kokkos::View<Uniform2DGrid[1]> grid_d("uniform grid");
     auto grid_h = Kokkos::create_mirror_view(grid_d);
-    grid_h(0) = Uniform2DGrid{.edge_length{1, 1}, .bot_left = {0, 0}, .divisions = {60, 60}};
+    grid_h(0) = Uniform2DGrid{
+      .edge_length{1, 1}, .bot_left = {0, 0}, .divisions = {60, 60}};
     Kokkos::deep_copy(grid_d, grid_h);
     // require number of candidates is >=1 and <=6
-    auto intersection_map = pcms::detail::construct_intersection_map_2d(mesh, grid_d, grid_h(0).GetNumCells());
+    auto intersection_map = pcms::detail::construct_intersection_map_2d(
+      mesh, grid_d, grid_h(0).GetNumCells());
 
     REQUIRE(intersection_map.numRows() == 3600);
     REQUIRE(num_candidates_within_range(intersection_map, 1, 6));
   }
 }
-TEST_CASE("uniform grid search") {
+TEST_CASE("uniform grid search")
+{
   using pcms::GridPointSearch2D;
   auto lib = Omega_h::Library{};
   auto world = lib.world();
   auto mesh =
     Omega_h::build_box(world, OMEGA_H_SIMPLEX, 1, 1, 1, 10, 10, 0, false);
-  auto tolerances = GridPointSearch2D::PointSearchTolerances { "point search 2d tolerances" };
+  auto tolerances =
+    GridPointSearch2D::PointSearchTolerances{"point search 2d tolerances"};
   tolerances(0) = 0.01;
   tolerances(1) = 0.01;
 
-  GridPointSearch2D search{mesh,10,10, tolerances};
+  GridPointSearch2D search{mesh, 10, 10, tolerances};
 
-  Kokkos::View<pcms::Real*[2]> points("test_points", 8);
-  //Kokkos::View<pcms::Real*[2]> points("test_points", 1);
+  Kokkos::View<pcms::Real* [2]> points("test_points", 8);
+  // Kokkos::View<pcms::Real*[2]> points("test_points", 1);
   auto points_h = Kokkos::create_mirror_view(points);
-  points_h(0,0) = 0;
-  points_h(0,1) = 0;
-  points_h(1,0) = 0.55;
-  points_h(1,1) = 0.54;
-  points_h(2,0) = 100;
-  points_h(2,1) = 100;
-  points_h(3,0) = 1;
-  points_h(3,1) = 1;
-  points_h(4,0) = -1;
-  points_h(4,1) = -1;
+  points_h(0, 0) = 0;
+  points_h(0, 1) = 0;
+  points_h(1, 0) = 0.55;
+  points_h(1, 1) = 0.54;
+  points_h(2, 0) = 100;
+  points_h(2, 1) = 100;
+  points_h(3, 0) = 1;
+  points_h(3, 1) = 1;
+  points_h(4, 0) = -1;
+  points_h(4, 1) = -1;
   points_h(5, 0) = 1.01;
   points_h(5, 1) = 0.95;
   points_h(6, 0) = 0.05;
@@ -195,7 +202,7 @@ TEST_CASE("uniform grid search") {
   SECTION("global coordinate within mesh")
   {
     {
-      auto [dim, idx,coords] = results_h(0);
+      auto [dim, idx, coords] = results_h(0);
 
       CAPTURE(idx);
 
@@ -206,7 +213,7 @@ TEST_CASE("uniform grid search") {
       REQUIRE(coords[2] == Catch::Approx(0));
     }
     {
-      auto [dim, idx,coords] = results_h(1);
+      auto [dim, idx, coords] = results_h(1);
       REQUIRE(dim == GridPointSearch2D::Result::Dimensionality::EDGE);
       REQUIRE(idx == 156);
       REQUIRE(coords[0] == Catch::Approx(0.5));
@@ -214,22 +221,25 @@ TEST_CASE("uniform grid search") {
       REQUIRE(coords[2] == Catch::Approx(0.4));
     }
     {
-      auto [dim, idx,coords] = results_h(7);
+      auto [dim, idx, coords] = results_h(7);
       REQUIRE(dim == GridPointSearch2D::Result::Dimensionality::FACE);
       REQUIRE(idx == 0);
     }
   }
   // feature needs to be added
-  SECTION("Global coordinate outside mesh", "[!mayfail]") {
+  SECTION("Global coordinate outside mesh", "[!mayfail]")
+  {
     auto out_of_bounds = results_h(2);
     auto top_right = results_h(3);
-    REQUIRE(out_of_bounds.dimensionality == GridPointSearch2D::Result::Dimensionality::VERTEX);
-    REQUIRE(-1*out_of_bounds.element_id == top_right.element_id);
+    REQUIRE(out_of_bounds.dimensionality ==
+            GridPointSearch2D::Result::Dimensionality::VERTEX);
+    REQUIRE(-1 * out_of_bounds.element_id == top_right.element_id);
 
     out_of_bounds = results_h(4);
     auto bot_left = results_h(0);
-    REQUIRE(out_of_bounds.dimensionality == GridPointSearch2D::Result::Dimensionality::VERTEX);
-    REQUIRE(-1*out_of_bounds.element_id == bot_left.element_id);
+    REQUIRE(out_of_bounds.dimensionality ==
+            GridPointSearch2D::Result::Dimensionality::VERTEX);
+    REQUIRE(-1 * out_of_bounds.element_id == bot_left.element_id);
 
     out_of_bounds = results_h(5);
     REQUIRE(out_of_bounds.dimensionality ==

--- a/test/test_point_search.cpp
+++ b/test/test_point_search.cpp
@@ -5,7 +5,6 @@
 #include <Omega_h_build.hpp>
 
 using pcms::AABBox;
-using pcms::barycentric_from_global;
 using pcms::Uniform2DGrid;
 
 TEST_CASE("global to local")
@@ -14,7 +13,7 @@ TEST_CASE("global to local")
   SECTION("check verts")
   {
     for (int i = 0; i < coords.size(); ++i) {
-      auto xi = barycentric_from_global(coords[i], coords);
+      auto xi = Omega_h::barycentric_from_global<2, 2>(coords[i], coords);
       Omega_h::Vector<3> hand_xi{0, 0, 0};
       hand_xi[i] = 1;
       printf("[%f,%f,%f] == [%f,%f,%f]\n", xi[0], xi[1], xi[2], hand_xi[0],
@@ -25,7 +24,7 @@ TEST_CASE("global to local")
   SECTION("check point")
   {
     Omega_h::Vector<2> point{0.5, 0.5};
-    auto xi = barycentric_from_global(point, coords);
+    auto xi = Omega_h::barycentric_from_global<2, 2>(point, coords);
     Omega_h::Vector<3> hand_xi{0.25, 0.25, 0.5};
     printf("[%f,%f,%f] == [%f,%f,%f]\n", xi[0], xi[1], xi[2], hand_xi[0],
            hand_xi[1], hand_xi[2]);

--- a/test/test_point_search.cpp
+++ b/test/test_point_search.cpp
@@ -169,7 +169,7 @@ TEST_CASE("uniform grid search") {
 
   GridPointSearch2D search{mesh,10,10, tolerances};
 
-  Kokkos::View<pcms::Real*[2]> points("test_points", 7);
+  Kokkos::View<pcms::Real*[2]> points("test_points", 8);
   //Kokkos::View<pcms::Real*[2]> points("test_points", 1);
   auto points_h = Kokkos::create_mirror_view(points);
   points_h(0,0) = 0;
@@ -186,6 +186,8 @@ TEST_CASE("uniform grid search") {
   points_h(5, 1) = 0.95;
   points_h(6, 0) = 0.05;
   points_h(6, 1) = -0.01;
+  points_h(7, 0) = 0.05;
+  points_h(7, 1) = 0.02;
   Kokkos::deep_copy(points, points_h);
   auto results = search(points);
   auto results_h = Kokkos::create_mirror_view(results);
@@ -206,10 +208,15 @@ TEST_CASE("uniform grid search") {
     {
       auto [dim, idx,coords] = results_h(1);
       REQUIRE(dim == GridPointSearch2D::Result::Dimensionality::EDGE);
-      REQUIRE(idx == 91);
+      REQUIRE(idx == 156);
       REQUIRE(coords[0] == Catch::Approx(0.5));
       REQUIRE(coords[1] == Catch::Approx(0.1));
       REQUIRE(coords[2] == Catch::Approx(0.4));
+    }
+    {
+      auto [dim, idx,coords] = results_h(7);
+      REQUIRE(dim == GridPointSearch2D::Result::Dimensionality::FACE);
+      REQUIRE(idx == 0);
     }
   }
   // feature needs to be added
@@ -227,7 +234,7 @@ TEST_CASE("uniform grid search") {
     out_of_bounds = results_h(5);
     REQUIRE(out_of_bounds.dimensionality ==
             GridPointSearch2D::Result::Dimensionality::EDGE);
-    REQUIRE(-1 * out_of_bounds.element_id == top_right.element_id);
+    REQUIRE(out_of_bounds.element_id == 219);
 
     out_of_bounds = results_h(6);
     REQUIRE(out_of_bounds.dimensionality ==

--- a/test/test_point_search.cpp
+++ b/test/test_point_search.cpp
@@ -139,7 +139,7 @@ TEST_CASE("construct intersection map")
     auto grid_h = Kokkos::create_mirror_view(grid_d);
     grid_h(0) = Uniform2DGrid{.edge_length{1, 1}, .bot_left = {0, 0}, .divisions = {10, 10}};
     Kokkos::deep_copy(grid_d, grid_h);
-    auto intersection_map = pcms::detail::construct_intersection_map(mesh, grid_d, grid_h(0).GetNumCells());
+    auto intersection_map = pcms::detail::construct_intersection_map_2d(mesh, grid_d, grid_h(0).GetNumCells());
     // assert(cudaSuccess == cudaDeviceSynchronize());
     REQUIRE(intersection_map.numRows() == 100);
     REQUIRE(num_candidates_within_range(intersection_map, 2, 16));
@@ -151,7 +151,7 @@ TEST_CASE("construct intersection map")
     grid_h(0) = Uniform2DGrid{.edge_length{1, 1}, .bot_left = {0, 0}, .divisions = {60, 60}};
     Kokkos::deep_copy(grid_d, grid_h);
     // require number of candidates is >=1 and <=6
-    auto intersection_map = pcms::detail::construct_intersection_map(mesh, grid_d, grid_h(0).GetNumCells());
+    auto intersection_map = pcms::detail::construct_intersection_map_2d(mesh, grid_d, grid_h(0).GetNumCells());
 
     REQUIRE(intersection_map.numRows() == 3600);
     REQUIRE(num_candidates_within_range(intersection_map, 1, 6));

--- a/test/test_point_search.cpp
+++ b/test/test_point_search.cpp
@@ -163,7 +163,12 @@ TEST_CASE("uniform grid search") {
   auto world = lib.world();
   auto mesh =
     Omega_h::build_box(world, OMEGA_H_SIMPLEX, 1, 1, 1, 10, 10, 0, false);
-  GridPointSearch2D search{mesh,10,10};
+  auto tolerances = GridPointSearch2D::PointSearchTolerances { "point search 2d tolerances" };
+  tolerances(0) = 0.01;
+  tolerances(1) = 0.01;
+
+  GridPointSearch2D search{mesh,10,10, tolerances};
+
   Kokkos::View<pcms::Real*[2]> points("test_points", 7);
   //Kokkos::View<pcms::Real*[2]> points("test_points", 1);
   auto points_h = Kokkos::create_mirror_view(points);
@@ -189,7 +194,10 @@ TEST_CASE("uniform grid search") {
   {
     {
       auto [dim, idx,coords] = results_h(0);
-      REQUIRE(dim == GridPointSearch2D::Result::Dimensionality::FACE);
+
+      CAPTURE(idx);
+
+      REQUIRE(dim == GridPointSearch2D::Result::Dimensionality::VERTEX);
       REQUIRE(idx == 0);
       REQUIRE(coords[0] == Catch::Approx(1));
       REQUIRE(coords[1] == Catch::Approx(0));
@@ -197,7 +205,7 @@ TEST_CASE("uniform grid search") {
     }
     {
       auto [dim, idx,coords] = results_h(1);
-      REQUIRE(dim == GridPointSearch2D::Result::Dimensionality::FACE);
+      REQUIRE(dim == GridPointSearch2D::Result::Dimensionality::EDGE);
       REQUIRE(idx == 91);
       REQUIRE(coords[0] == Catch::Approx(0.5));
       REQUIRE(coords[1] == Catch::Approx(0.1));

--- a/test/test_point_search.cpp
+++ b/test/test_point_search.cpp
@@ -209,21 +209,21 @@ TEST_CASE("uniform grid search") {
     auto out_of_bounds = results_h(2);
     auto top_right = results_h(3);
     REQUIRE(out_of_bounds.dimensionality == GridPointSearch2D::Result::Dimensionality::VERTEX);
-    REQUIRE(-1*out_of_bounds.tri_id == top_right.tri_id);
+    REQUIRE(-1*out_of_bounds.element_id == top_right.element_id);
 
     out_of_bounds = results_h(4);
     auto bot_left = results_h(0);
     REQUIRE(out_of_bounds.dimensionality == GridPointSearch2D::Result::Dimensionality::VERTEX);
-    REQUIRE(-1*out_of_bounds.tri_id == bot_left.tri_id);
+    REQUIRE(-1*out_of_bounds.element_id == bot_left.element_id);
 
     out_of_bounds = results_h(5);
     REQUIRE(out_of_bounds.dimensionality ==
             GridPointSearch2D::Result::Dimensionality::EDGE);
-    REQUIRE(-1 * out_of_bounds.tri_id == top_right.tri_id);
+    REQUIRE(-1 * out_of_bounds.element_id == top_right.element_id);
 
     out_of_bounds = results_h(6);
     REQUIRE(out_of_bounds.dimensionality ==
             GridPointSearch2D::Result::Dimensionality::EDGE);
-    REQUIRE(-1 * out_of_bounds.tri_id == bot_left.tri_id);
+    REQUIRE(-1 * out_of_bounds.element_id == bot_left.element_id);
   }
 }

--- a/test/test_point_search.cpp
+++ b/test/test_point_search.cpp
@@ -112,8 +112,7 @@ bool num_candidates_within_range(const T& intersection_map, pcms::LO min,
   Kokkos::parallel_reduce(
     intersection_map.numRows(),
     KOKKOS_LAMBDA(const int i, result_type& update) {
-      auto num_candidates =
-        intersection_map.row_map(i + 1) - intersection_map.row_map(i);
+      auto num_candidates = intersection_map.row_map(i + 1) - intersection_map.row_map(i);
       if (num_candidates > update.max_val)
         update.max_val = num_candidates;
       if (num_candidates < update.min_val)
@@ -125,11 +124,11 @@ bool num_candidates_within_range(const T& intersection_map, pcms::LO min,
     std::cerr << result.min_val << ' ' << result.max_val << '\n';
   return within_range;
 }
-// extern Omega_h::Library omega_h_library;
+//extern Omega_h::Library omega_h_library;
 
 TEST_CASE("construct intersection map")
 {
-  // auto world = omega_h_library.world();
+  //auto world = omega_h_library.world();
   auto lib = Omega_h::Library{};
   auto world = lib.world();
   auto mesh =
@@ -139,11 +138,9 @@ TEST_CASE("construct intersection map")
   {
     Kokkos::View<Uniform2DGrid[1]> grid_d("uniform grid");
     auto grid_h = Kokkos::create_mirror_view(grid_d);
-    grid_h(0) = Uniform2DGrid{
-      .edge_length{1, 1}, .bot_left = {0, 0}, .divisions = {10, 10}};
+    grid_h(0) = Uniform2DGrid{.edge_length{1, 1}, .bot_left = {0, 0}, .divisions = {10, 10}};
     Kokkos::deep_copy(grid_d, grid_h);
-    auto intersection_map = pcms::detail::construct_intersection_map(
-      mesh, grid_d, grid_h(0).GetNumCells());
+    auto intersection_map = pcms::detail::construct_intersection_map(mesh, grid_d, grid_h(0).GetNumCells());
     // assert(cudaSuccess == cudaDeviceSynchronize());
     REQUIRE(intersection_map.numRows() == 100);
     REQUIRE(num_candidates_within_range(intersection_map, 2, 16));
@@ -152,38 +149,35 @@ TEST_CASE("construct intersection map")
   {
     Kokkos::View<Uniform2DGrid[1]> grid_d("uniform grid");
     auto grid_h = Kokkos::create_mirror_view(grid_d);
-    grid_h(0) = Uniform2DGrid{
-      .edge_length{1, 1}, .bot_left = {0, 0}, .divisions = {60, 60}};
+    grid_h(0) = Uniform2DGrid{.edge_length{1, 1}, .bot_left = {0, 0}, .divisions = {60, 60}};
     Kokkos::deep_copy(grid_d, grid_h);
     // require number of candidates is >=1 and <=6
-    auto intersection_map = pcms::detail::construct_intersection_map(
-      mesh, grid_d, grid_h(0).GetNumCells());
+    auto intersection_map = pcms::detail::construct_intersection_map(mesh, grid_d, grid_h(0).GetNumCells());
 
     REQUIRE(intersection_map.numRows() == 3600);
     REQUIRE(num_candidates_within_range(intersection_map, 1, 6));
   }
 }
-TEST_CASE("uniform grid search")
-{
-  using pcms::GridPointSearch;
+TEST_CASE("uniform grid search") {
+  using pcms::GridPointSearch2D;
   auto lib = Omega_h::Library{};
   auto world = lib.world();
   auto mesh =
     Omega_h::build_box(world, OMEGA_H_SIMPLEX, 1, 1, 1, 10, 10, 0, false);
-  GridPointSearch search{mesh, 10, 10};
-  Kokkos::View<pcms::Real* [2]> points("test_points", 7);
-  // Kokkos::View<pcms::Real*[2]> points("test_points", 1);
+  GridPointSearch2D search{mesh,10,10};
+  Kokkos::View<pcms::Real*[2]> points("test_points", 7);
+  //Kokkos::View<pcms::Real*[2]> points("test_points", 1);
   auto points_h = Kokkos::create_mirror_view(points);
-  points_h(0, 0) = 0;
-  points_h(0, 1) = 0;
-  points_h(1, 0) = 0.55;
-  points_h(1, 1) = 0.54;
-  points_h(2, 0) = 100;
-  points_h(2, 1) = 100;
-  points_h(3, 0) = 1;
-  points_h(3, 1) = 1;
-  points_h(4, 0) = -1;
-  points_h(4, 1) = -1;
+  points_h(0,0) = 0;
+  points_h(0,1) = 0;
+  points_h(1,0) = 0.55;
+  points_h(1,1) = 0.54;
+  points_h(2,0) = 100;
+  points_h(2,1) = 100;
+  points_h(3,0) = 1;
+  points_h(3,1) = 1;
+  points_h(4,0) = -1;
+  points_h(4,1) = -1;
   points_h(5, 0) = 1.01;
   points_h(5, 1) = 0.95;
   points_h(6, 0) = 0.05;
@@ -195,16 +189,16 @@ TEST_CASE("uniform grid search")
   SECTION("global coordinate within mesh")
   {
     {
-      auto [dim, idx, coords] = results_h(0);
-      REQUIRE(dim == GridPointSearch::Result::Dimensionality::FACE);
+      auto [dim, idx,coords] = results_h(0);
+      REQUIRE(dim == GridPointSearch2D::Result::Dimensionality::FACE);
       REQUIRE(idx == 0);
       REQUIRE(coords[0] == Catch::Approx(1));
       REQUIRE(coords[1] == Catch::Approx(0));
       REQUIRE(coords[2] == Catch::Approx(0));
     }
     {
-      auto [dim, idx, coords] = results_h(1);
-      REQUIRE(dim == GridPointSearch::Result::Dimensionality::FACE);
+      auto [dim, idx,coords] = results_h(1);
+      REQUIRE(dim == GridPointSearch2D::Result::Dimensionality::FACE);
       REQUIRE(idx == 91);
       REQUIRE(coords[0] == Catch::Approx(0.5));
       REQUIRE(coords[1] == Catch::Approx(0.1));
@@ -212,28 +206,25 @@ TEST_CASE("uniform grid search")
     }
   }
   // feature needs to be added
-  SECTION("Global coordinate outside mesh", "[!mayfail]")
-  {
+  SECTION("Global coordinate outside mesh", "[!mayfail]") {
     auto out_of_bounds = results_h(2);
     auto top_right = results_h(3);
-    REQUIRE(out_of_bounds.dimensionality ==
-            GridPointSearch::Result::Dimensionality::VERTEX);
-    REQUIRE(-1 * out_of_bounds.tri_id == top_right.tri_id);
+    REQUIRE(out_of_bounds.dimensionality == GridPointSearch2D::Result::Dimensionality::VERTEX);
+    REQUIRE(-1*out_of_bounds.tri_id == top_right.tri_id);
 
     out_of_bounds = results_h(4);
     auto bot_left = results_h(0);
-    REQUIRE(out_of_bounds.dimensionality ==
-            GridPointSearch::Result::Dimensionality::VERTEX);
-    REQUIRE(-1 * out_of_bounds.tri_id == bot_left.tri_id);
+    REQUIRE(out_of_bounds.dimensionality == GridPointSearch2D::Result::Dimensionality::VERTEX);
+    REQUIRE(-1*out_of_bounds.tri_id == bot_left.tri_id);
 
     out_of_bounds = results_h(5);
     REQUIRE(out_of_bounds.dimensionality ==
-            GridPointSearch::Result::Dimensionality::EDGE);
+            GridPointSearch2D::Result::Dimensionality::EDGE);
     REQUIRE(-1 * out_of_bounds.tri_id == top_right.tri_id);
 
     out_of_bounds = results_h(6);
     REQUIRE(out_of_bounds.dimensionality ==
-            GridPointSearch::Result::Dimensionality::EDGE);
+            GridPointSearch2D::Result::Dimensionality::EDGE);
     REQUIRE(-1 * out_of_bounds.tri_id == bot_left.tri_id);
   }
 }


### PR DESCRIPTION
This pull request introduces significant generalization and refactoring of the point localization and search infrastructure, preparing the codebase for both 2D and 3D mesh support. The changes include replacing hardcoded 2D structures with dimension-agnostic templates, introducing new search classes and functors for 3D, and improving the robustness and clarity of the point search logic.

**Generalization and Refactoring for Dimension-Agnostic Support:**

* Introduced template functions and classes such as `simplex_bbox`, `within_bbox`, `bbox_verts_within_simplex`, and `simplex_intersects_bbox` to generalize bounding box and intersection logic for arbitrary dimensions, replacing 2D-specific implementations. [[1]](diffhunk://#diff-b6ad98d142d76056630fef89bd0d6d47d7f0dfb5b7944b7937c9410f08d479d0R60-R84) [[2]](diffhunk://#diff-b6ad98d142d76056630fef89bd0d6d47d7f0dfb5b7944b7937c9410f08d479d0R145-R155) [[3]](diffhunk://#diff-b6ad98d142d76056630fef89bd0d6d47d7f0dfb5b7944b7937c9410f08d479d0L138-R214) [[4]](diffhunk://#diff-b6ad98d142d76056630fef89bd0d6d47d7f0dfb5b7944b7937c9410f08d479d0R247-R255)
* Added `GridTriIntersectionFunctor3D` and corresponding `construct_intersection_map_3d` to support 3D mesh intersection, alongside renaming and refactoring the 2D functor and intersection map construction for clarity.

**Search Infrastructure Modernization:**

* Refactored `GridPointSearch` to `GridPointSearch2D` and replaced `std::optional` with `std::unique_ptr` for the `search_` member in `OmegaHField`, making the design ready for alternative search strategies and consistent with modern C++ practices. [[1]](diffhunk://#diff-99d06de5a096fc7d2d770098d38052caf69a3771f66c24a1da51750cc9258872L156-R162) [[2]](diffhunk://#diff-99d06de5a096fc7d2d770098d38052caf69a3771f66c24a1da51750cc9258872L222-R222) [[3]](diffhunk://#diff-b6ad98d142d76056630fef89bd0d6d47d7f0dfb5b7944b7937c9410f08d479d0L285-R407)

**Point Search Logic and API Improvements:**

* Enhanced the point search operator to robustly distinguish between vertex, edge, and face hits, using a new tolerance structure (`PointSearchTolerances`) and improving the logic for nearest element detection and classification. [[1]](diffhunk://#diff-b6ad98d142d76056630fef89bd0d6d47d7f0dfb5b7944b7937c9410f08d479d0L308-R433) [[2]](diffhunk://#diff-b6ad98d142d76056630fef89bd0d6d47d7f0dfb5b7944b7937c9410f08d479d0L323-R472) [[3]](diffhunk://#diff-b6ad98d142d76056630fef89bd0d6d47d7f0dfb5b7944b7937c9410f08d479d0L357-R543)
* Updated result structures and usages to reflect the new naming and dimensionality (e.g., `element_id` instead of `tri_id`, `GridPointSearch2D::Result`), and improved error checking and reporting. [[1]](diffhunk://#diff-8ae2b6b4c8d7626823f1d4b7a53c72af20072a31f11bba1c2bda678675d95cdeL27-R34) [[2]](diffhunk://#diff-8ae2b6b4c8d7626823f1d4b7a53c72af20072a31f11bba1c2bda678675d95cdeL121-R121) [[3]](diffhunk://#diff-8ae2b6b4c8d7626823f1d4b7a53c72af20072a31f11bba1c2bda678675d95cdeL132-R132)

These changes collectively make the codebase more extensible, robust, and ready for future 3D mesh support.